### PR TITLE
docs: add security policy and disclosure workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ Example tool roots:
 
 - If installer output says `No supported tools detected`, install one supported tool first, then re-run.
 - If a download fails, verify network access and check `curl --version`.
+
+## Project Policies
+
+- [Security Policy](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+Thank you for helping keep **design-farmer** secure.
+
+## Supported Versions
+
+Security fixes are applied to the default branch (`main`) and included in the next release.
+
+| Version | Supported |
+| --- | --- |
+| `main` | ✅ |
+| Older snapshots | ❌ |
+
+## Reporting a Vulnerability
+
+Please **do not open a public issue** for suspected security vulnerabilities.
+
+Use one of these channels:
+
+1. Preferred: GitHub Private Vulnerability Reporting  
+   https://github.com/ohprettyhak/design-farmer/security/advisories/new
+2. If private reporting is unavailable, contact the maintainer directly and include:
+   - Vulnerability summary
+   - Reproduction steps / proof-of-concept
+   - Impact assessment
+   - Suggested remediation (if known)
+
+## Response Expectations
+
+- Initial acknowledgment: within **3 business days**
+- Triage decision: within **7 business days**
+- Coordinated fix and disclosure timeline: shared after triage based on severity
+
+## Disclosure Process
+
+1. We validate the report and assess severity.
+2. A fix is prepared and reviewed privately.
+3. We publish a coordinated disclosure and remediation guidance.
+
+Please provide enough detail for maintainers to reproduce the issue quickly.


### PR DESCRIPTION
## Summary
- add `SECURITY.md` with a responsible disclosure process, report requirements, and response SLA
- define supported version policy (`main`) and coordinated disclosure steps for maintainers/reporters
- link the new policy from `README.md` under Project Policies for visibility

## Verification
- ran: `bash scripts/validate-skill-md.sh` (pass)

Closes #7