### PR TITLE
docs: add pull request template with verification checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- Describe the problem this PR solves and why this change is needed. -->
+
+## Change Intent
+
+- Type: <!-- feature | fix | docs | chore | refactor -->
+- Related issue(s): <!-- e.g. Closes #123 -->
+- Scope: <!-- files/modules impacted -->
+
+## Validation Evidence
+
+<!-- Paste command output or summarize concrete results. -->
+
+- [ ] Ran `bash scripts/validate-skill-md.sh`
+- [ ] Ran tests relevant to changed code/docs
+- [ ] Confirmed no unexpected file changes
+
+## Impact Notes
+
+<!-- Explain user-visible impact and any migration/release notes. -->
+
+- User-facing impact:
+- Risks / rollback plan:
+- Follow-up work (if any):
+
+## Checklist
+
+- [ ] Documentation updated to match behavior changes
+- [ ] Acceptance criteria from linked issue are addressed
+- [ ] PR title/message reflects the purpose of the change


### PR DESCRIPTION
## Summary
- add `.github/pull_request_template.md` with required sections for summary, intent, validation evidence, and impact notes
- include mandatory checklist items for docs alignment, acceptance criteria coverage, and PR quality signals
- add explicit validation checkboxes so reviewers can quickly confirm execution evidence

## Verification
- ran: `bash scripts/validate-skill-md.sh` (pass)

Closes #6