### PR TITLE
docs: add issue templates for feature and quality gaps

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/ohprettyhak/design-farmer/security/advisories/new
+    about: Please use private reporting for security issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Propose a new capability or improvement for design-farmer
+title: "[FEATURE REQUEST] "
+labels:
+  - feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or maintainer problem are you trying to solve?
+      placeholder: Describe the current pain point and why it matters.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What change should be introduced?
+      placeholder: Describe the proposed approach and expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who is impacted and what is the expected outcome?
+      placeholder: Explain user impact, scope, and urgency.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Define concrete completion criteria.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/quality_gap.yml
+++ b/.github/ISSUE_TEMPLATE/quality_gap.yml
@@ -1,0 +1,56 @@
+name: Quality gap report
+description: Report documentation, validation, consistency, or workflow quality gaps
+title: "[QUALITY GAP] "
+labels:
+  - quality
+body:
+  - type: dropdown
+    id: category
+    attributes:
+      label: Gap category
+      options:
+        - Documentation
+        - Validation / CI
+        - Skill structure
+        - Process / workflow
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: Current state
+      description: What is happening now?
+      placeholder: Describe the observed behavior or missing standard.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_state
+    attributes:
+      label: Expected state
+      description: What should happen instead?
+      placeholder: Define the target quality bar.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include logs, screenshots, links, or file paths.
+      placeholder: Add concrete evidence that helps maintainers triage quickly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Define how we know the gap is resolved.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- add GitHub issue forms for feature requests and quality gap reports with required fields
- enforce structured triage inputs (problem/proposal/impact/acceptance criteria and quality evidence)
- configure issue creation to disable blank issues and route security reports to private advisory reporting

## Verification
- ran: `bash scripts/validate-skill-md.sh` (pass)
- ran: LSP diagnostics for `.github/ISSUE_TEMPLATE/*.yml` (0 diagnostics)

Closes #5