### PR TITLE
docs: add changelog and release note process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,6 @@
 ## Checklist
 
 - [ ] Documentation updated to match behavior changes
+- [ ] `CHANGELOG.md` updated for user-visible changes (or marked N/A)
 - [ ] Acceptance criteria from linked issue are addressed
 - [ ] PR title/message reflects the purpose of the change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- README installation guide and multi-tool installer support.
+- PR template with verification checklist.
+- README health/freshness badges.
+
+### Changed
+- Skill quality automation and validation workflow improvements.
+
+### Fixed
+- N/A
+
+## Release Entry Format
+
+When preparing a release, move relevant items from `Unreleased` into a version section:
+
+```md
+## [x.y.z] - YYYY-MM-DD
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+```
+
+Only include user-visible or maintainer-relevant changes.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,8 @@ Example tool roots:
 
 - If installer output says `No supported tools detected`, install one supported tool first, then re-run.
 - If a download fails, verify network access and check `curl --version`.
+
+## Project Maintenance
+
+- [Changelog](CHANGELOG.md)
+- [Release Notes Process](RELEASE_PROCESS.md)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,22 @@
+# Release Notes Process
+
+This process keeps changelog updates consistent and reviewable.
+
+## During Every Pull Request
+
+1. Determine if the change is user-visible or operationally significant.
+2. If yes, add an item under the relevant subsection in `CHANGELOG.md` -> `## [Unreleased]`.
+3. Keep entries short and outcome-focused (why it matters).
+4. Include issue/PR references when useful.
+
+## During Release Preparation
+
+1. Create a new version section in `CHANGELOG.md` using the documented format.
+2. Move finalized entries from `Unreleased` into the new version section.
+3. Keep `Unreleased` present for subsequent work.
+4. Use the new section as the source for GitHub release notes.
+
+## Review Expectations
+
+- PRs with user-facing changes should not merge without a matching changelog entry.
+- Reviewers verify changelog quality (clear, concise, and accurate scope).


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md` with an `Unreleased` section and a clear release entry format
- add `RELEASE_PROCESS.md` to define PR-time and release-time changelog responsibilities
- update README and PR template so changelog updates are enforced and discoverable

## Verification
- ran: `bash scripts/validate-skill-md.sh` (pass)
- attempted LSP diagnostics for Markdown files; no `.md` LSP server is configured in this repo

Closes #9