### PR TITLE
ci: add install.sh smoke tests in workflow matrix

### DIFF
--- a/.github/workflows/skill-quality.yml
+++ b/.github/workflows/skill-quality.yml
@@ -15,3 +15,24 @@ jobs:
 
       - name: Run skill structure validation
         run: bash scripts/validate-skill-md.sh
+
+  install-smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shell: [bash, zsh]
+        tool: [claude, codex, amp, gemini, opencode]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure zsh is available
+        run: |
+          if ! command -v zsh >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y zsh
+          fi
+
+      - name: Run installer smoke tests
+        run: ${{ matrix.shell }} -lc "bash scripts/test-install-smoke.sh ${{ matrix.tool }}"

--- a/scripts/test-install-smoke.sh
+++ b/scripts/test-install-smoke.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="$ROOT_DIR/install.sh"
+
+if [[ ! -f "$INSTALLER" ]]; then
+  echo "ERROR: Missing installer script: $INSTALLER"
+  exit 1
+fi
+
+tool_marker_path() {
+  case "$1" in
+    claude) echo "$2/.claude" ;;
+    codex) echo "$2/.agents" ;;
+    amp) echo "$2/.config/agents" ;;
+    gemini) echo "$2/.gemini" ;;
+    opencode) echo "$2/.config/opencode" ;;
+    *)
+      echo "ERROR: Unknown tool '$1'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+installed_skill_file_path() {
+  case "$1" in
+    claude) echo "$2/.claude/skills/design-farmer/SKILL.md" ;;
+    codex) echo "$2/.agents/skills/design-farmer/SKILL.md" ;;
+    amp) echo "$2/.config/agents/skills/design-farmer/SKILL.md" ;;
+    gemini) echo "$2/.gemini/skills/design-farmer/SKILL.md" ;;
+    opencode) echo "$2/.config/opencode/skills/design-farmer/SKILL.md" ;;
+    *)
+      echo "ERROR: Unknown tool '$1'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq "$expected" "$file"; then
+    echo "ERROR: Expected '$expected' in $file"
+    echo "----- $file -----"
+    cat "$file"
+    echo "-----------------"
+    exit 1
+  fi
+}
+
+write_curl_stub() {
+  local stub_bin="$1"
+  mkdir -p "$stub_bin"
+  cat >"$stub_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file=""
+url=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output_file="$2"
+      shift 2
+      ;;
+    -f|-s|-S|-L|-fsSL)
+      shift
+      ;;
+    *)
+      if [[ "$1" != -* ]]; then
+        url="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$output_file" ]]; then
+  echo "missing -o argument" >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$output_file")"
+printf "stub skill content\n" >"$output_file"
+
+if [[ -n "${SMOKE_CURL_LOG:-}" ]]; then
+  printf "%s\n" "$url" >>"$SMOKE_CURL_LOG"
+fi
+EOF
+  chmod +x "$stub_bin/curl"
+}
+
+test_successful_install_for_tool() {
+  local tool="$1"
+  local branch="$2"
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  local log_file="$temp_dir/curl-urls.log"
+
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "$tool" "$fake_home")"
+  write_curl_stub "$fake_bin"
+
+  local stdout_file="$temp_dir/stdout.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" SMOKE_CURL_LOG="$log_file" BRANCH="$branch" \
+    /usr/bin/bash "$INSTALLER" >"$stdout_file" 2>&1
+
+  local installed_file
+  installed_file="$(installed_skill_file_path "$tool" "$fake_home")"
+
+  if [[ ! -f "$installed_file" ]]; then
+    echo "ERROR: Expected installed file not found: $installed_file"
+    echo "----- installer output -----"
+    cat "$stdout_file"
+    echo "----------------------------"
+    exit 1
+  fi
+
+  assert_contains "$installed_file" "stub skill content"
+  assert_contains "$stdout_file" "Done!"
+  assert_contains "$log_file" "https://raw.githubusercontent.com/ohprettyhak/design-farmer/${branch}/skills/design-farmer/SKILL.md"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_no_supported_tools_fails() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  write_curl_stub "$fake_bin"
+
+  local output_file="$temp_dir/output.log"
+  set +e
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" /usr/bin/bash "$INSTALLER" >"$output_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "ERROR: Installer should fail when no supported tool markers exist"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "No supported tools detected."
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_missing_curl_fails() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local path_without_curl="$temp_dir/no-curl-bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$path_without_curl"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/output.log"
+  set +e
+  HOME="$fake_home" PATH="$path_without_curl" /usr/bin/bash "$INSTALLER" >"$output_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "ERROR: Installer should fail when curl is unavailable"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "required command not found: curl"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+main() {
+  local tool="${1:-}"
+  if [[ -z "$tool" ]]; then
+    echo "Usage: $0 <tool>"
+    echo "Valid tools: claude codex amp gemini opencode"
+    exit 1
+  fi
+
+  local smoke_branch="smoke-test-branch"
+
+  echo "[smoke] success path for tool: $tool"
+  test_successful_install_for_tool "$tool" "$smoke_branch"
+
+  echo "[smoke] failure path: no supported tools"
+  test_no_supported_tools_fails
+
+  echo "[smoke] failure path: missing curl prerequisite"
+  test_missing_curl_fails
+
+  echo "All installer smoke tests passed for tool=$tool"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `scripts/test-install-smoke.sh` to validate installer success output paths and failure behavior in isolated temporary homes.
- Extend `.github/workflows/skill-quality.yml` with an `install-smoke` matrix job across `bash`/`zsh` and all supported tool environments (`claude`, `codex`, `amp`, `gemini`, `opencode`).
- Verify branch override handling and prerequisite failures (`curl` missing, no supported tools detected) to catch installer regressions before merge.

## Verification
- `bash scripts/validate-skill-md.sh`
- `for tool in claude codex amp gemini opencode; do bash scripts/test-install-smoke.sh \"$tool\"; done`
- `for tool in claude codex amp gemini opencode; do zsh -lc \"bash scripts/test-install-smoke.sh $tool\"; done`