### PR TITLE
fix: improve dark mode reliability and remove Storybook version hardcoding

### DIFF
--- a/skills/design-farmer/SKILL.md
+++ b/skills/design-farmer/SKILL.md
@@ -1542,17 +1542,266 @@ Use that version throughout — do NOT assume any specific major version number.
    - @storybook/addon-a11y (accessibility checking)
    - @storybook/addon-themes (dark mode toggle)
    - @storybook/addon-docs (auto documentation)
-3. Create stories for every implemented component:
-   - Default story showing all variants
-   - Interactive story with controls for all props
-   - Accessibility story with aria attribute demonstrations
-   - Theme story showing light/dark appearance
-4. Configure .storybook/preview.ts:
-   - Load theme CSS files
+3. Configure .storybook/preview.ts:
+   - Import the design system's global CSS (tokens, reset, theme files)
    - Set up theme decorator for dark mode toggle (see 'Storybook Dark Mode Decorator' below)
-   - Configure viewport presets
+   - Configure viewport presets (mobile: 375px, tablet: 768px, desktop: 1280px)
+   - Enable autodocs for automatic API documentation generation
+4. Create stories for every implemented component following the Polymorphic Coverage
+   Matrix defined in Step 3 below.
 ")
 ```
+
+**Step 3 — Polymorphic Coverage Story Generation:**
+
+Every component MUST have stories covering the following 11 dimensions. This ensures
+that all visual variants, interactive states, and edge cases are documented and testable.
+
+Use CSF3 format (Component Story Format 3) with `Meta` + `StoryObj` typing for all stories.
+
+**Story file naming convention:** `{ComponentName}.stories.tsx`
+
+**Dimension 1 — Variant Axis (CRITICAL):**
+Every visual variant of a component gets its own named story export, PLUS an AllVariants
+grid story showing all variants side-by-side for comparison.
+
+```tsx
+// Example: Button.stories.tsx
+export const Primary: Story = { args: { variant: 'primary', children: 'Primary' } }
+export const Secondary: Story = { args: { variant: 'secondary', children: 'Secondary' } }
+export const Ghost: Story = { args: { variant: 'ghost', children: 'Ghost' } }
+export const Danger: Story = { args: { variant: 'danger', children: 'Danger' } }
+
+// Grid story: all variants in one view
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      {['primary', 'secondary', 'ghost', 'danger'].map(v => (
+        <Button key={v} variant={v}>{v}</Button>
+      ))}
+    </div>
+  ),
+}
+```
+
+**Dimension 2 — Size Axis (CRITICAL):**
+Every size option gets a dedicated story, PLUS an AllSizes comparison story.
+
+```tsx
+export const Small: Story = { args: { size: 'sm', children: 'Small' } }
+export const Medium: Story = { args: { size: 'md', children: 'Medium' } }
+export const Large: Story = { args: { size: 'lg', children: 'Large' } }
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+      {['sm', 'md', 'lg'].map(s => (
+        <Button key={s} size={s}>{s}</Button>
+      ))}
+    </div>
+  ),
+}
+```
+
+**Dimension 3 — State Axis (CRITICAL):**
+Interactive states: disabled, loading, error. Use `play` functions for hover/focus/active.
+
+```tsx
+export const Disabled: Story = { args: { disabled: true, children: 'Disabled' } }
+export const Loading: Story = { args: { loading: true, children: 'Loading...' } }
+
+// Play function for interaction testing
+export const FocusState: Story = {
+  play: async ({ canvasElement }) => {
+    const button = canvasElement.querySelector('button')
+    button?.focus()
+  },
+}
+```
+
+**Dimension 4 — Theme Axis:**
+Theme decorator already applied globally (Step 3 above). Add a dedicated side-by-side
+comparison story per component:
+
+```tsx
+export const ThemeComparison: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '2rem' }}>
+      <div data-theme="light" style={{ padding: '1rem', background: 'var(--surface-primary)' }}>
+        <Button variant="primary">Light Mode</Button>
+      </div>
+      <div data-theme="dark" style={{ padding: '1rem', background: 'var(--surface-primary)' }}>
+        <Button variant="primary">Dark Mode</Button>
+      </div>
+    </div>
+  ),
+}
+```
+
+**Dimension 5 — Color Axis:**
+For components with a `color` prop, create a color palette grid:
+
+```tsx
+export const AllColors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+      {['primary', 'success', 'warning', 'danger', 'info'].map(c => (
+        <Badge key={c} color={c}>{c}</Badge>
+      ))}
+    </div>
+  ),
+}
+```
+
+**Dimension 6 — Composition Axis (CRITICAL):**
+Compound components (Select, Dialog, Tabs, Menu, Form) need stories showing the
+full part assembly:
+
+```tsx
+// Example: Dialog composition story
+export const FullComposition: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild><Button>Open Dialog</Button></DialogTrigger>
+      <DialogContent>
+        <DialogTitle>Title</DialogTitle>
+        <DialogDescription>Description text</DialogDescription>
+        <DialogClose asChild><Button variant="ghost">Close</Button></DialogClose>
+      </DialogContent>
+    </Dialog>
+  ),
+}
+
+// Minimal composition
+export const BasicComposition: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger>Open</DialogTrigger>
+      <DialogContent><DialogTitle>Title</DialogTitle></DialogContent>
+    </Dialog>
+  ),
+}
+
+// Real-world usage pattern
+export const ConfirmationDialog: Story = {
+  render: () => (
+    <Dialog>
+      <DialogTrigger asChild><Button variant="danger">Delete</Button></DialogTrigger>
+      <DialogContent>
+        <DialogTitle>Are you sure?</DialogTitle>
+        <DialogDescription>This action cannot be undone.</DialogDescription>
+        <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+          <DialogClose asChild><Button variant="ghost">Cancel</Button></DialogClose>
+          <Button variant="danger">Delete</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  ),
+}
+```
+
+**Dimension 7 — Slot / Children Axis:**
+Show all possible children patterns:
+
+```tsx
+export const TextOnly: Story = { args: { children: 'Button' } }
+export const WithLeadingIcon: Story = { args: { children: <><IconPlus /> Add Item</> } }
+export const WithTrailingIcon: Story = { args: { children: <>Next <IconArrowRight /></> } }
+export const IconOnly: Story = { args: { children: <IconSearch />, 'aria-label': 'Search' } }
+export const WithBadge: Story = { args: { children: <>Inbox <Badge>3</Badge></> } }
+```
+
+**Dimension 8 — Polymorphic `as` / `asChild` Axis:**
+If a component supports rendering as different elements:
+
+```tsx
+export const AsButton: Story = { args: { children: 'Button (default)' } }
+export const AsLink: Story = {
+  args: { asChild: true, children: <a href="#">As Link</a> },
+}
+export const AsRouterLink: Story = {
+  args: { asChild: true, children: <Link href="/page">Router Link</Link> },
+}
+```
+
+**Dimension 9 — Responsive Axis:**
+Use Storybook viewport parameters:
+
+```tsx
+export const Mobile: Story = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+  args: { children: 'Mobile view', fullWidth: true },
+}
+export const Tablet: Story = {
+  parameters: { viewport: { defaultViewport: 'tablet' } },
+}
+```
+
+**Dimension 10 — Accessibility Axis:**
+Keyboard navigation and focus management via play functions:
+
+```tsx
+export const KeyboardNavigation: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole('button')
+    await userEvent.tab()  // focus trigger
+    await userEvent.keyboard('{Enter}')  // open
+    await userEvent.keyboard('{Escape}')  // close
+  },
+}
+
+export const FocusTrap: Story = {
+  name: 'Focus Trap (Dialog)',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button'))
+    // Tab should cycle within dialog, not escape to background
+    await userEvent.tab()
+    await userEvent.tab()
+    await userEvent.tab()
+  },
+}
+```
+
+**Dimension 11 — Edge Case Axis:**
+Boundary conditions and unusual content:
+
+```tsx
+export const LongText: Story = {
+  args: { children: 'This is a very long button label that should handle overflow gracefully' },
+}
+export const EmptyChildren: Story = { args: { children: '' } }
+export const Overflow: Story = {
+  decorators: [(Story) => <div style={{ width: '100px' }}><Story /></div>],
+  args: { children: 'Overflow container test' },
+}
+```
+
+**Coverage verification checklist** — After generating all stories, verify:
+
+```
+[ ] Every component has a .stories.tsx file
+[ ] Every prop with discrete options has individual named stories + AllX grid story
+[ ] Every interactive state has a story (disabled, loading, error if applicable)
+[ ] Compound components have Basic, Full, and RealWorld composition stories
+[ ] Theme comparison story exists for every component
+[ ] Play functions test keyboard navigation for interactive components
+[ ] Edge case stories exist (long text, empty, overflow)
+[ ] Polymorphic as/asChild patterns have dedicated stories (if component supports it)
+[ ] `npm run storybook` starts without errors
+[ ] All stories render correctly in both light and dark themes
+```
+
+**Story count expectation by component type:**
+
+| Component Type | Minimum Stories | Example |
+|---------------|----------------|---------|
+| Simple (Button, Badge) | 15-25 | Variants + Sizes + States + Slots + Theme + Edge |
+| Form (Input, Select) | 10-20 | States + Validation + Composition + Accessibility |
+| Compound (Dialog, Tabs) | 8-15 | Basic + Full + RealWorld + Keyboard + FocusTrap |
+| Layout (Stack, Grid) | 5-10 | Directions + Spacing + Responsive + Nested |
+| Typography (Heading, Text) | 5-8 | Levels + Weights + Truncation + As polymorphic |
 
 **Step 3 — Storybook Dark Mode Decorator Configuration:**
 


### PR DESCRIPTION
## Summary
- Add comprehensive next-themes setup guide with `suppressHydrationWarning` on `<html>` (required per official docs)
- Add `mounted` guard pattern, `resolvedTheme` usage, and Tailwind CSS dark mode integration guide
- Remove hardcoded Storybook 8.x references; now queries npm for latest stable version before install
- Add Storybook dark mode decorator configuration with attribute alignment table
- Add new section 4.8: Dark Mode Implementation Checklist & Common Failures (12-item checklist + 12 failure patterns with root cause and fix)
- Add Attribute Alignment Reference (Strategy A: data-theme, Strategy B: class) ensuring ThemeProvider, CSS, Tailwind, and Storybook all use the same mechanism
- Increase Dark Mode Quality weight from 5% to 10% in both the scoring rubric and the Design System Critic reviewer
- Add 11-dimension Polymorphic Coverage Matrix for Storybook story generation, replacing the previous 4-bullet prompt

## Dark Mode Changes

### Problem
- `suppressHydrationWarning` was missing from `<html>` — every Next.js page load with next-themes emitted React hydration warnings
- No guidance on `resolvedTheme` vs `theme`, causing `'system'` to leak into UI logic
- No mounted guard pattern, leading to hydration mismatches in theme-dependent components
- Storybook decorator could silently mismatch the app's ThemeProvider attribute

### Solution
- Section 4.6: Step-by-step next-themes setup (layout.tsx → ThemeProvider wrapper → hydration guard → Tailwind integration)
- Section 4.8: Mandatory checklist (12 items) + failure pattern table (12 patterns with root cause and fix)
- Phase 7: Storybook decorator examples for both `withThemeByDataAttribute` and `withThemeByClassName` with critical alignment rule table
- Phase 8.5: Expanded Dark Mode Quality criteria from 4 visual checks to 16 items across infrastructure, visual, and component-level verification

## Storybook Version Changes

### Problem
Hardcoded "Storybook 8.x" references become stale as Storybook releases new major versions.

### Solution
- Remove all version-specific references
- Add `npm view storybook version` step before installation
- Require addon version compatibility verification against installed Storybook major version

## Storybook Polymorphic Coverage Matrix

### Problem
Phase 7 had only 4 generic bullets for story generation ("Default story showing all variants", "Interactive story with controls", "Accessibility story", "Theme story"), achieving ~10.9% of full polymorphic coverage across 11 dimensions. Phase 6 defines rich component contracts (5 variants, 5 sizes, 7 interactive states, 6 compound component families, asChild pattern) that Phase 7 completely ignored.

### Solution
Add 11-dimension coverage matrix with CSF3 code examples for each:

| Dimension | Coverage | Priority |
|-----------|----------|----------|
| D1: Variant axis | Individual + AllVariants grid stories | CRITICAL |
| D2: Size axis | Per-size + AllSizes comparison | CRITICAL |
| D3: State axis | Disabled, Loading, Error + play functions | CRITICAL |
| D4: Theme axis | Side-by-side light/dark comparison | LOW (already covered) |
| D5: Color axis | Color palette grid for color-prop components | HIGH |
| D6: Composition axis | Basic, Full, RealWorld compound stories | CRITICAL |
| D7: Slot/children axis | TextOnly, WithIcon, IconOnly, WithBadge | HIGH |
| D8: Polymorphic as axis | AsButton, AsLink, AsRouterLink | HIGH |
| D9: Responsive axis | Viewport-parameterized stories | MEDIUM |
| D10: Accessibility axis | Keyboard nav + focus trap play functions | HIGH |
| D11: Edge case axis | LongText, EmptyChildren, Overflow | MEDIUM |

Includes coverage verification checklist and minimum story count expectations per component type (Simple: 15-25, Form: 10-20, Compound: 8-15, Layout: 5-10, Typography: 5-8).

## Scoring Weight Adjustment
- Dark Mode Quality: 5% → **10%** (infrastructure + visual + component-level checks)
- Spacing & Rhythm: 15% → **10%** (rebalanced to maintain 100% total)

## Test plan
- [x] `scripts/validate-skill-md.sh` passes
- [ ] Run design-farmer on a Next.js project → verify `suppressHydrationWarning` in generated layout.tsx
- [ ] Run Phase 7 → verify `npm view storybook version` is executed before install
- [ ] Run Phase 7 → verify stories cover all 11 dimensions per component
- [ ] Run Phase 8.5 → verify expanded Dark Mode Quality checklist is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)