### PR TITLE
refactor: split the skill bundle and harden bundle integrity validation

### DIFF
--- a/skills/design-farmer/SKILL.md
+++ b/skills/design-farmer/SKILL.md
@@ -67,17 +67,21 @@ If the script is missing, fails, or times out, continue silently — never block
 This skill is distributed as a **bundle**: the router `SKILL.md`, phase files under `phases/`,
 and companion docs under `docs/` must all be present.
 
-Before starting work:
+Before starting work, Read `phases/operational-notes.md` to verify the bundle is accessible.
 
-1. Read `phases/operational-notes.md`.
-2. Verify the phase file for the current step exists before proceeding.
-3. If any required phase file or companion file is missing, STOP immediately and report:
+Before each phase, Read the corresponding phase file using the **Read** tool with its full path
+(e.g., `Read("~/.claude/skills/design-farmer/phases/phase-0-preflight.md")`).
+If the Read call fails (file not found), the bundle is incomplete — STOP immediately and report:
 
 ```
 Status: BLOCKED
 Reason: Incomplete Design Farmer bundle — required file missing: {path}
 AskUserQuestion: "The installed Design Farmer skill bundle is incomplete (`{path}` is missing). Please reinstall or provide the missing file before I continue."
 ```
+
+**Important**: Do NOT use Glob or Search tools with patterns like `phases/*.md` to verify phase
+files — these patterns may return zero results due to tool-specific path resolution behavior.
+Always use Read with the exact file path.
 
 Do NOT guess missing phase behavior from memory.
 


### PR DESCRIPTION
## Summary
- split the Design Farmer runtime into a router plus phase and companion bundle files, and clarify the bundle integrity gate so phase availability is verified with exact-path `Read` calls instead of glob patterns
- harden bundle installation by downloading the full skill bundle atomically, adding rollback behavior, and expanding smoke coverage for successful installs and partial-download failure recovery
- tighten repository contracts and verification coverage across `AGENTS.md`, project docs, the structural validator, semantic consistency checks, and exhaustive path simulation

## Change Intent

- Type: refactor
- Related issue(s): fixes bundle integrity gate guidance and bundle validation behavior
- Scope: `skills/design-farmer/**`, `scripts/**`, `install.sh`, `docs/**`, `AGENTS.md`, `CONTRIBUTING.md`, `CLAUDE.md`

## Validation Evidence

- Ran `bash scripts/validate-skill-md.sh`
  - Result: `All skill structure and contract checks passed.`
- Ran `bash skills/design-farmer/tests/run-all.sh`
  - Structural validation: passed
  - Semantic consistency: `72 passed, 0 failed, 0 warnings`
  - Exhaustive simulation: `169 passed, 0 failed, 0 warnings`
  - Final result: `ALL SUITES PASSED`
- Confirmed PR branch validation in an isolated worktree at `/tmp/design-farmer-pr54`

## Impact Notes

- User-facing impact: the distributed skill now expects and installs a complete multi-file bundle, and the runtime guidance now explicitly avoids unreliable glob-based bundle checks
- Risks / rollback plan: installer and validation behavior changed together; rollback is straightforward by reverting this branch, which restores the prior single-file assumptions and installer behavior
- Follow-up work (if any): none required for this PR

## Checklist

- [x] Documentation updated to match behavior changes
- [x] Acceptance criteria from linked issue are addressed
- [x] PR title/message reflects the purpose of the change