### PR TITLE
feat: add selective installer target options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 - `.github/`: GitHub configuration.
   - `.github/workflows/skill-quality.yml`: CI pipeline (structural validation + install smoke tests).
   - `.github/pull_request_template.md`: PR template with validation evidence checklist.
-- `install.sh`: Automated installer (detects tools, downloads skill bundle atomically).
+- `install.sh`: Automated installer (detects tools, supports selective target flags, downloads skill bundle atomically).
 - `AGENTS.md`: This file — repository-wide rules.
 - `CONTRIBUTING.md`: Contributor workflow (branch naming, commit convention, PR requirements).
 - `README.md`: Project overview, installation, and documentation links.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -12,7 +12,37 @@ The installer will:
 
 1. Detect supported local tools.
 2. Create each tool-specific skill directory if needed.
-3. Download `skills/design-farmer/SKILL.md` and the full phase bundle into each detected tool.
+3. Download `skills/design-farmer/SKILL.md` and the full phase bundle into selected targets.
+
+### Installer options
+
+```bash
+bash install.sh [options]
+```
+
+- `--tool <name>`: install only for a specific tool (repeatable)
+- `--all`: install for all detected tools (default behavior)
+- `--interactive`: choose targets interactively (uses `fzf --multi` when available; otherwise numeric fallback)
+- `--dry-run`: show resolved targets without writing files
+- `--list-tools`: show supported tools with detection status and exit
+
+Valid tool names: `claude`, `codex`, `amp`, `gemini`, `opencode`
+
+Examples:
+
+```bash
+# Install only for Claude Code
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --tool claude
+
+# Install only for Codex and Gemini
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --tool codex --tool gemini
+
+# Interactively pick install targets
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --interactive
+
+# Preview targets only
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --dry-run
+```
 
 Supported tools:
 
@@ -43,3 +73,4 @@ Example tool roots:
 
 - If installer output says `No supported tools detected`, install one supported tool first, then re-run.
 - If a download fails, verify network access and check `curl --version`.
+- If you run `--interactive` in a non-TTY environment (for example CI), use `--tool` instead.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 
 The installer detects your tools, creates skill directories, and downloads the skill bundle. Supported tools: **Claude Code**, **Codex CLI**, **Amp**, **Gemini CLI**, **OpenCode**.
 
+Selective install examples:
+
+```bash
+# Install only for Claude Code
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --tool claude
+
+# Install only for Codex CLI
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --tool codex
+
+# Preview targets without writing files
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --dry-run
+```
+
 For manual installation or troubleshooting, see [INSTALLATION.md](INSTALLATION.md).
 
 ## Documentation

--- a/docs/project-design-farmer.md
+++ b/docs/project-design-farmer.md
@@ -27,7 +27,7 @@ Before this project, agents had no repeatable workflow for:
 - Phase instruction files under `phases/`.
 - Companion documentation (`PHASE-INDEX.md`, `QUALITY-GATES.md`, `MAINTENANCE.md`, `EXAMPLES-GALLERY.md`).
 - Greenfield reference example (`examples/DESIGN.md` — Nova UI).
-- Automated installer (`install.sh`) with atomic bundle deployment.
+- Automated installer (`install.sh`) with atomic bundle deployment and selective target options (`--tool`, `--interactive`, `--dry-run`).
 - Structural validation script (`scripts/validate-skill-md.sh`).
 - Semantic consistency test suite (`tests/test-semantic-consistency.sh`).
 - CI pipeline (GitHub Actions: structural validation + install smoke tests).
@@ -150,6 +150,7 @@ Phase 0 (Preflight) ──→ detect topology, check DESIGN.md
 - [x] Semantic consistency tests (72 checks) pass with zero failures.
 - [x] Exhaustive simulation (169 checks, 1152 paths) passes with zero failures.
 - [x] Installer deploys bundle atomically across 5 AI tools.
+- [x] Installer supports selective target installation (`--tool`, `--interactive`) and preview mode (`--dry-run`).
 - [x] CI pipeline runs on every PR and push to `main`.
 - [x] DESIGN.md Config fields survive Phase 4.5 → Phase 0 round-trip (14 fields).
 - [x] Radius tone preference (`radiusTone`) is captured in discovery and propagated through re-entry/config templates.
@@ -181,3 +182,4 @@ Phase 0 (Preflight) ──→ detect topology, check DESIGN.md
 | 2026-04-06 | Hak Lee | Initial draft |
 | 2026-04-09 | Codex | Updated re-entry contract to context-first flow and documented CI anti-drift guards |
 | 2026-04-09 | Codex | Added DESIGN.md source-classification decision to prevent false corruption handling for readable third-party docs |
+| 2026-04-09 | Codex | Added installer selective-target contract (`--tool`, `--interactive`, `--dry-run`) and acceptance criteria |

--- a/install.sh
+++ b/install.sh
@@ -136,8 +136,202 @@ tool_label() {
   esac
 }
 
+is_supported_tool() {
+  local candidate="$1"
+  local tool
+  for tool in "${TOOLS[@]}"; do
+    if [ "$tool" = "$candidate" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+print_usage() {
+  cat <<'EOF'
+Usage: install.sh [options]
+
+Options:
+  --tool <name>     Install only for the given tool (repeatable)
+                    Valid: claude, codex, amp, gemini, opencode
+  --all             Install for all detected tools (default behavior)
+  --interactive     Select install targets interactively
+  --dry-run         Show resolved install targets without writing files
+  --list-tools      List supported tools and detected status, then exit
+  -h, --help        Show this help message
+EOF
+}
+
+list_tools() {
+  local tool
+  printf "%bSupported tools%b\n" "$BOLD" "$RESET"
+  for tool in "${TOOLS[@]}"; do
+    local marker
+    local status="not detected"
+    marker="$(tool_marker "$tool")"
+    if [ -d "$marker" ]; then
+      status="detected"
+    fi
+    printf "  - %-8s %-12s %s\n" "$tool" "[$status]" "$marker"
+  done
+}
+
+append_unique_tool() {
+  local candidate="$1"
+  local existing
+  for existing in "${SELECTED[@]}"; do
+    if [ "$existing" = "$candidate" ]; then
+      return 0
+    fi
+  done
+  SELECTED+=("$candidate")
+}
+
+select_interactively() {
+  if [ "${#DETECTED[@]}" -eq 0 ]; then
+    printf "%bError:%b --interactive requires at least one detected tool.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+
+  if [ ! -t 1 ] || [ ! -r /dev/tty ]; then
+    printf "%bError:%b --interactive requires an interactive terminal.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+
+  printf "%bInteractive target selection%b\n" "$BOLD" "$RESET"
+
+  if command -v fzf >/dev/null 2>&1; then
+    printf "Use Space to toggle, Enter to confirm.\n\n"
+    local chosen=()
+    local picked
+    while IFS= read -r picked; do
+      chosen+=("$picked")
+    done < <(printf "%s\n" "${DETECTED[@]}" | fzf --multi --prompt "Select install targets > " --height 40% --border --layout=reverse)
+
+    if [ "${#chosen[@]}" -eq 0 ]; then
+      printf "%bError:%b no tools selected.\n" "$RED" "$RESET" >&2
+      exit 1
+    fi
+
+    SELECTED=("${chosen[@]}")
+    return 0
+  fi
+
+  printf "fzf not found. Falling back to numeric selection.\n"
+  printf "Enter comma-separated numbers (example: 1,3).\n\n"
+
+  local i=1
+  local tool
+  for tool in "${DETECTED[@]}"; do
+    printf "  %d) %s\n" "$i" "$(tool_label "$tool")"
+    i=$((i + 1))
+  done
+
+  printf "\nSelection: "
+  local raw_input
+  IFS= read -r raw_input </dev/tty
+  if [ -z "$raw_input" ]; then
+    printf "%bError:%b no tools selected.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+
+  local parts
+  IFS=',' read -r -a parts <<<"$raw_input"
+  local part
+  for part in "${parts[@]}"; do
+    local idx
+    idx="${part//[[:space:]]/}"
+
+    if [[ ! "$idx" =~ ^[0-9]+$ ]]; then
+      printf "%bError:%b invalid selection '%s'.\n" "$RED" "$RESET" "$part" >&2
+      exit 1
+    fi
+    if [ "$idx" -lt 1 ] || [ "$idx" -gt "${#DETECTED[@]}" ]; then
+      printf "%bError:%b selection out of range: %s.\n" "$RED" "$RESET" "$idx" >&2
+      exit 1
+    fi
+
+    append_unique_tool "${DETECTED[$((idx - 1))]}"
+  done
+
+  if [ "${#SELECTED[@]}" -eq 0 ]; then
+    printf "%bError:%b no tools selected.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+}
+
 TOOLS=(claude codex amp gemini opencode)
 DETECTED=()
+REQUESTED_TOOLS=()
+SELECTED=()
+USE_ALL=0
+INTERACTIVE=0
+DRY_RUN=0
+LIST_ONLY=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tool)
+      if [ "$#" -lt 2 ]; then
+        printf "%bError:%b --tool requires a value.\n" "$RED" "$RESET" >&2
+        exit 1
+      fi
+      REQUESTED_TOOLS+=("$2")
+      shift 2
+      ;;
+    --all)
+      USE_ALL=1
+      shift
+      ;;
+    --interactive)
+      INTERACTIVE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --list-tools)
+      LIST_ONLY=1
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      printf "%bError:%b unknown option: %s\n\n" "$RED" "$RESET" "$1" >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+  for tool in "${TOOLS[@]}"; do
+    marker="$(tool_marker "$tool")"
+    if [ -d "$marker" ]; then
+      DETECTED+=("$tool")
+    fi
+  done
+  list_tools
+  exit 0
+fi
+
+if [ "$INTERACTIVE" -eq 1 ] && [ "${#REQUESTED_TOOLS[@]}" -gt 0 ]; then
+  printf "%bError:%b --interactive cannot be combined with --tool.\n" "$RED" "$RESET" >&2
+  exit 1
+fi
+
+if [ "$INTERACTIVE" -eq 1 ] && [ "$USE_ALL" -eq 1 ]; then
+  printf "%bError:%b --interactive cannot be combined with --all.\n" "$RED" "$RESET" >&2
+  exit 1
+fi
+
+if [ "$USE_ALL" -eq 1 ] && [ "${#REQUESTED_TOOLS[@]}" -gt 0 ]; then
+  printf "%bError:%b --all cannot be combined with --tool.\n" "$RED" "$RESET" >&2
+  exit 1
+fi
 
 for tool in "${TOOLS[@]}"; do
   marker="$(tool_marker "$tool")"
@@ -146,11 +340,31 @@ for tool in "${TOOLS[@]}"; do
   fi
 done
 
-require_command curl
-
 printf "%bInstalling design-farmer skill%b\n\n" "$BOLD" "$RESET"
 
-if [ "${#DETECTED[@]}" -eq 0 ]; then
+if [ "$INTERACTIVE" -eq 1 ]; then
+  select_interactively
+elif [ "${#REQUESTED_TOOLS[@]}" -gt 0 ]; then
+  for tool in "${REQUESTED_TOOLS[@]}"; do
+    if ! is_supported_tool "$tool"; then
+      printf "%bError:%b unsupported tool '%s'.\n" "$RED" "$RESET" "$tool" >&2
+      print_usage >&2
+      exit 1
+    fi
+    append_unique_tool "$tool"
+  done
+elif [ "$USE_ALL" -eq 1 ] || [ "${#REQUESTED_TOOLS[@]}" -eq 0 ]; then
+  SELECTED=("${DETECTED[@]}")
+fi
+
+if [ "$DRY_RUN" -eq 1 ] && [ "${#REQUESTED_TOOLS[@]}" -eq 0 ] && [ "$INTERACTIVE" -eq 0 ] && [ "${#SELECTED[@]}" -eq 0 ]; then
+  printf "%bDry run%b — no files will be written.\n\n" "$BOLD" "$RESET"
+  printf "No supported tools detected. Nothing to install.\n"
+  printf "%bDone (dry run).%b\n" "$GREEN" "$RESET"
+  exit 0
+fi
+
+if [ "${#SELECTED[@]}" -eq 0 ]; then
   printf "%bNo supported tools detected.%b\n" "$YELLOW" "$RESET"
   printf "Install one of these first, then run this script again:\n"
   printf "  - Claude Code:  https://claude.ai/code\n"
@@ -161,9 +375,34 @@ if [ "${#DETECTED[@]}" -eq 0 ]; then
   exit 1
 fi
 
+if [ "$DRY_RUN" -eq 0 ]; then
+  require_command curl
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf "%bDry run%b — no files will be written.\n\n" "$BOLD" "$RESET"
+fi
+
+printf "Selected targets:\n"
+for tool in "${SELECTED[@]}"; do
+  target_dir="$(tool_skill_dir "$tool")"
+  marker="$(tool_marker "$tool")"
+  status="detected"
+  if [ ! -d "$marker" ]; then
+    status="not detected"
+  fi
+  printf "  - %s (%s) -> %s\n" "$(tool_label "$tool")" "$status" "$target_dir"
+done
+printf "\n"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf "%bDone (dry run).%b\n" "$GREEN" "$RESET"
+  exit 0
+fi
+
 FAILED=0
 
-for tool in "${DETECTED[@]}"; do
+for tool in "${SELECTED[@]}"; do
   target_dir="$(tool_skill_dir "$tool")"
   label="$(tool_label "$tool")"
 

--- a/scripts/test-install-smoke.sh
+++ b/scripts/test-install-smoke.sh
@@ -56,7 +56,7 @@ installed_skill_dir_path() {
 assert_contains() {
   local file="$1"
   local expected="$2"
-  if ! grep -Fq "$expected" "$file"; then
+  if ! grep -Fq -- "$expected" "$file"; then
     echo "ERROR: Expected '$expected' in $file"
     echo "----- $file -----"
     cat "$file"
@@ -154,6 +154,173 @@ test_successful_install_for_tool() {
   assert_contains "$log_file" "https://raw.githubusercontent.com/ohprettyhak/design-farmer/${branch}/skills/design-farmer/phases/phase-0-preflight.md"
   assert_contains "$log_file" "https://raw.githubusercontent.com/ohprettyhak/design-farmer/${branch}/skills/design-farmer/phases/phase-11-readiness-handoff.md"
   assert_contains "$log_file" "https://raw.githubusercontent.com/ohprettyhak/design-farmer/${branch}/skills/design-farmer/docs/PHASE-INDEX.md"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_selective_tool_install_only_writes_requested_target() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+  mkdir -p "$(tool_marker_path "codex" "$fake_home")"
+  write_curl_stub "$fake_bin"
+
+  local output_file="$temp_dir/output.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" BRANCH="smoke-test-branch" \
+    "$BASH_BIN" "$INSTALLER" --tool codex >"$output_file" 2>&1
+
+  local codex_file
+  codex_file="$(installed_skill_file_path "codex" "$fake_home")"
+  local claude_file
+  claude_file="$(installed_skill_file_path "claude" "$fake_home")"
+
+  if [[ ! -f "$codex_file" ]]; then
+    echo "ERROR: Expected codex install target was not written"
+    cat "$output_file"
+    exit 1
+  fi
+
+  if [[ -f "$claude_file" ]]; then
+    echo "ERROR: Unexpected claude install target was written"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "Selected targets:"
+  assert_contains "$output_file" "Codex CLI"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_dry_run_does_not_write_files() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/output.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" \
+    "$BASH_BIN" "$INSTALLER" --tool claude --dry-run >"$output_file" 2>&1
+
+  local claude_dir
+  claude_dir="$(installed_skill_dir_path "claude" "$fake_home")"
+  if [[ -d "$claude_dir" ]]; then
+    echo "ERROR: dry-run should not create skill directory"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "Dry run"
+  assert_contains "$output_file" "Done (dry run)."
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_dry_run_without_detected_tools_succeeds() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+
+  local output_file="$temp_dir/output.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" \
+    "$BASH_BIN" "$INSTALLER" --dry-run >"$output_file" 2>&1
+
+  assert_contains "$output_file" "No supported tools detected. Nothing to install."
+  assert_contains "$output_file" "Done (dry run)."
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_list_tools_reports_status_and_exits() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/output.log"
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$INSTALLER" --list-tools >"$output_file" 2>&1
+
+  assert_contains "$output_file" "Supported tools"
+  assert_contains "$output_file" "claude"
+  assert_contains "$output_file" "[detected]"
+  assert_contains "$output_file" "codex"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_conflicting_flags_fail() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/output.log"
+  set +e
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$INSTALLER" --all --tool claude >"$output_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "ERROR: Installer should fail for conflicting flags"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "--all cannot be combined with --tool"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_interactive_requires_terminal() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/output.log"
+  set +e
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$INSTALLER" --interactive >"$output_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "ERROR: Installer should fail for --interactive without TTY"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "--interactive requires an interactive terminal"
 
   rm -rf "$temp_dir"
   trap - RETURN
@@ -273,6 +440,24 @@ main() {
 
   echo "[smoke] success path for tool: $tool"
   test_successful_install_for_tool "$tool" "$smoke_branch"
+
+  echo "[smoke] selective path: --tool installs only requested target"
+  test_selective_tool_install_only_writes_requested_target
+
+  echo "[smoke] dry-run path: no files are written"
+  test_dry_run_does_not_write_files
+
+  echo "[smoke] dry-run path: no detected tools still succeeds"
+  test_dry_run_without_detected_tools_succeeds
+
+  echo "[smoke] info path: --list-tools reports statuses"
+  test_list_tools_reports_status_and_exits
+
+  echo "[smoke] parser path: conflicting flags fail"
+  test_conflicting_flags_fail
+
+  echo "[smoke] interactive path: requires terminal in CI"
+  test_interactive_requires_terminal
 
   echo "[smoke] failure path: no supported tools"
   test_no_supported_tools_fails


### PR DESCRIPTION
## Summary
- add selective installer options to `install.sh`: `--tool` (repeatable), `--all`, `--interactive`, `--dry-run`, `--list-tools`, and `--help`
- preserve default behavior (no flags still installs to all detected tools), while enabling targeted installs and dry-run previews
- extend installer smoke tests for selective install paths, list-tools output, conflict validation, dry-run with no detected tools, and non-TTY interactive guard

## Why
Users with multiple supported tools installed were getting unintended all-target installs from the default installer flow. This change adds explicit target selection and safer preview controls while maintaining backward compatibility.

## Validation
- `bash scripts/validate-skill-md.sh`
- `bash skills/design-farmer/tests/run-all.sh`
- `bash scripts/test-install-smoke.sh claude`
- `bash scripts/test-install-smoke.sh codex`
- `bash scripts/test-install-smoke.sh amp`
- `bash scripts/test-install-smoke.sh gemini`
- `bash scripts/test-install-smoke.sh opencode`

Closes #82.