### PR TITLE
fix: align phase gating and pipeline state contracts

### DIFF
--- a/scripts/validate-skill-md.sh
+++ b/scripts/validate-skill-md.sh
@@ -198,12 +198,44 @@ index_required_contracts=(
   "one-at-a-time"
   "explicit verification evidence"
   "context"
+  "storybookSkipped"
+  "visualQASkipped"
+  "integrationStatus"
+  "visualQAMode"
+  "do not append"
 )
 for contract in "${index_required_contracts[@]}"; do
   if ! echo "$INDEX_CROSS_SECTION" | grep -Fq "$contract"; then
     echo "ERROR: Cross-phase contract missing from PHASE-INDEX.md: '$contract'"
     echo "  File: docs/PHASE-INDEX.md, section: '## Cross-Phase Contracts'"
     echo "  Contract: phase index must stay aligned with SKILL.md cross-phase contracts"
+    exit 1
+  fi
+done
+
+echo "Validating QUALITY-GATES.md optional skip policy..."
+QUALITY_SECTION=$(awk '/^## 2\) Behavioral Gates/{found=1; next} found && /^## /{exit} found' "$QUALITY_GATES_FILE")
+if [[ -z "$QUALITY_SECTION" ]]; then
+  echo "ERROR: '## 2) Behavioral Gates' section in QUALITY-GATES.md is missing or empty"
+  echo "  File: docs/QUALITY-GATES.md"
+  echo "  Contract: behavioral gates must remain explicit and parseable"
+  exit 1
+fi
+
+quality_required_markers=(
+  "completed phases"
+  "user-optional skipped phases"
+  "storybookSkipped"
+  "visualQASkipped"
+  "integrationStatus"
+  "visualQAMode"
+  "must not append"
+)
+for marker in "${quality_required_markers[@]}"; do
+  if ! echo "$QUALITY_SECTION" | grep -Fq "$marker"; then
+    echo "ERROR: QUALITY-GATES.md missing optional skip policy marker: '$marker'"
+    echo "  File: docs/QUALITY-GATES.md, section: '## 2) Behavioral Gates'"
+    echo "  Contract: quality gates must document skip-state fields and non-append behavior"
     exit 1
   fi
 done

--- a/skills/design-farmer/SKILL.md
+++ b/skills/design-farmer/SKILL.md
@@ -246,7 +246,7 @@ Phase 11: Release Readiness & Handoff
 ### Cross-Phase Contracts
 
 - **DesignFarmerConfig** (from Phase 1) is passed to all subsequent phases. Persisted to `{systemPath}/.design-farmer/config.json` for context-window resilience.
-- **Pipeline state tracking**: Every phase appends its ID to `completedPhases` in config.json upon completion. `createdAt` is set once in Phase 1. Phase 8 writes `lastReviewScore` (0–10) and `lastReviewDate`. Phase 0 displays this state during re-entry.
+- **Pipeline state tracking**: Completed and degraded phases append their IDs to `completedPhases` in config.json. User-optional skipped phases record dedicated skip state instead and do not append. `createdAt` is set once in Phase 1. Phase 8 writes `lastReviewScore` (0–10) and `lastReviewDate`. Phase 0 displays this state during re-entry.
 - **Design Maturity** (from Phase 2) is written to `DesignFarmerConfig.designMaturity` and determines the implementation path in Phases 3, 3.5, 5, and 6. Phase 0 re-entry may set a preliminary `designMaturity` from user input; Phase 2's formal assessment overrides this value.
 - **Existing DESIGN.md** detected in Phase 0 triggers a re-entry prompt — importing it as context continues to Phase 1 with pre-filled defaults. Critical discovery gates (scope/headless/theme decisions) must still be explicitly confirmed.
 - **DESIGN.md source classification**: Phase 0 distinguishes `internal-canonical` vs `external-context`. Readable third-party docs are context (not corruption); only unreadable files are treated as corrupted.

--- a/skills/design-farmer/docs/PHASE-INDEX.md
+++ b/skills/design-farmer/docs/PHASE-INDEX.md
@@ -22,12 +22,12 @@ This index provides a compact map of the Design Farmer router + phase bundle for
    - Convert and normalize color systems, generate scales, validate contrast.
    - Generate early DESIGN.md draft with extraction results for context resilience.
 5. **Phase 3.5: Visual Preview**
-   - Maturity-conditional preview opt-in: mandatory for GREENFIELD, recommended for EMERGING, default skip for MATURE.
-   - Generate self-contained HTML preview at `.design-farmer/design-preview.html`.
-   - Color palette swatches, typography specimens, spacing scale, sample components.
-   - Theme toggle for light/dark comparison.
-   - If preview skipped, text-only approval gate via opt-in gate (3.5.0) — not the error-state fallback (3.5.3).
-   - User approval gate before Phase 4 begins (always, regardless of preview mode).
+    - Maturity-conditional preview opt-in: mandatory for GREENFIELD, recommended for EMERGING, and ask-user with a skip recommendation for MATURE.
+    - Generate self-contained HTML preview at `.design-farmer/design-preview.html`.
+    - Color palette swatches, typography specimens, spacing scale, sample components.
+    - Theme toggle for light/dark comparison.
+    - If preview skipped, text-only approval happens at gate 3.5.0 — not the error-state fallback (3.5.3).
+    - User approval is always required before Phase 4, but the approval gate lives in 3.5.0 for text-only mode and 3.5.2 for generated-preview mode.
 
 6. **Phase 4: Architecture Design**
    - Define token hierarchy, directory structure, build pipeline, and CSS layering.
@@ -62,11 +62,12 @@ This index provides a compact map of the Design Farmer router + phase bundle for
 - Completion statuses are mandatory: `DONE`, `DONE_WITH_CONCERNS`, `BLOCKED`, `NEEDS_CONTEXT`.
 - User-question gating in Discovery must remain one-at-a-time.
 - Final completion requires explicit verification evidence.
-- Pipeline state (`completedPhases`, `createdAt`, `lastReviewScore`, `lastReviewDate`, `generatePreview`) is tracked in `config.json` and displayed during Phase 0 re-entry.
+- Pipeline state (`completedPhases`, `createdAt`, `lastReviewScore`, `lastReviewDate`, `generatePreview`, `storybookSkipped`, `visualQASkipped`, `integrationStatus`, `visualQAMode`) is tracked in `config.json` and displayed during Phase 0 re-entry as applicable.
 - Existing `DESIGN.md` is context input, not an auto-skip trigger for Phases 1–4.5; discovery gates remain required.
 - Readable third-party DESIGN.md files are `external-context` inputs, not corruption events.
 - Early DESIGN.md draft (Phase 3) bridges the extraction→source-of-truth context gap.
 - Preview file lives at `.design-farmer/design-preview.html` (not project root).
+- User-optional skipped phases do not append to `completedPhases`; they record dedicated skip state instead (`storybookSkipped`, `visualQASkipped`, `integrationStatus: "skipped"`, `visualQAMode: 'skipped'`).
 
 ## Section vs Phase Numbering
 

--- a/skills/design-farmer/docs/QUALITY-GATES.md
+++ b/skills/design-farmer/docs/QUALITY-GATES.md
@@ -26,7 +26,9 @@ This document defines release-quality checks for maintainers updating the Design
 - Phase 3.5 preview approval (maturity-conditional opt-in), Phase 4.5 DESIGN.md generation, and Phase 11 readiness handoff remain aligned with the current lifecycle.
 - Phase 0 re-entry with existing DESIGN.md must preserve context import semantics: pre-fill defaults, but still run critical Discovery decision gates.
 - Phase 0 re-entry must classify DESIGN.md source (`internal-canonical` vs `external-context`) and must not label readable third-party DESIGN.md as corrupted.
-- Every phase must append its ID to `completedPhases` in config.json upon completion.
+- Pipeline state guidance must distinguish completed phases from user-optional skipped phases.
+- User-optional skips must record dedicated state fields in config.json: `storybookSkipped`, `visualQASkipped`, `integrationStatus`, and `visualQAMode` where applicable.
+- User-optional skipped phases must not append their phase IDs to `completedPhases`; only completed or degraded executions append.
 - Phase 3 must generate an early DESIGN.md draft without overwriting existing files.
 - Phase 3.5 preview file must be generated inside `.design-farmer/`, not the project root.
 

--- a/skills/design-farmer/tests/test-semantic-consistency.sh
+++ b/skills/design-farmer/tests/test-semantic-consistency.sh
@@ -25,6 +25,16 @@ pass() { PASS=$((PASS + 1)); echo "  ✓ $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  ✗ $1"; }
 warn() { WARN=$((WARN + 1)); echo "  ⚠ $1"; }
 
+last_nonempty_lines() {
+  local file="$1"
+  local count="$2"
+  awk -v count="$count" 'NF { lines[++n] = $0 } END {
+    start = n - count + 1
+    if (start < 1) start = 1
+    for (i = start; i <= n; i++) print lines[i]
+  }' "$file"
+}
+
 # ---------------------------------------------------------------------------
 # TEST 1: Cross-Reference Section Number Validation
 # Verifies that handoff messages reference section numbers that exist in target files.
@@ -178,17 +188,18 @@ echo ""
 
 # ---------------------------------------------------------------------------
 # TEST 4: Status Message Completeness
-# Every phase file must end with a **Status: DONE** (or similar) pattern.
 # ---------------------------------------------------------------------------
 echo "=== TEST 4: Status Message Completeness ==="
 
 for phase_file in "$PHASES_DIR"/phase-*.md; do
   basename_file=$(basename "$phase_file")
 
-  if grep -qE '\*\*Status: (DONE|BLOCKED|DONE_WITH_CONCERNS|NEEDS_CONTEXT)\*\*' "$phase_file"; then
+  status_tail=$(last_nonempty_lines "$phase_file" 8)
+
+  if echo "$status_tail" | grep -qE '\*\*Status: (DONE|BLOCKED|DONE_WITH_CONCERNS|NEEDS_CONTEXT)\*\*'; then
     pass "$basename_file has completion status"
   else
-    fail "$basename_file missing completion status pattern"
+    fail "$basename_file missing completion status near file end"
   fi
 done
 
@@ -249,8 +260,7 @@ while [ $i -lt ${#handoff_sources[@]} ]; do
     continue
   fi
 
-  # Check last 5 lines for the next phase reference
-  status_area=$(tail -5 "$full_path")
+  status_area=$(last_nonempty_lines "$full_path" 8)
 
   if echo "$status_area" | grep -qF "$expected"; then
     pass "$src → $expected"
@@ -565,6 +575,55 @@ if grep -q "completedPhases" "$SKILL_FILE"; then
   pass "SKILL.md: documents completedPhases contract"
 else
   fail "SKILL.md: missing completedPhases contract"
+fi
+
+if grep -q "storybookSkipped" "$SKILL_FILE" &&
+   grep -q "visualQASkipped" "$SKILL_FILE" &&
+   grep -q "integrationStatus: \"skipped\"" "$SKILL_FILE" &&
+   grep -q "visualQAMode" "$SKILL_FILE"; then
+  pass "SKILL.md: documents dedicated skip-state fields"
+else
+  fail "SKILL.md: missing one or more dedicated skip-state fields"
+fi
+
+if grep -Fq "storybookSkipped: true" "$PHASES_DIR/phase-7-storybook.md" &&
+   grep -Eq "Do NOT append.*phase-7.*completedPhases" "$PHASES_DIR/phase-7-storybook.md"; then
+  pass "Phase 7: skip path records storybookSkipped without completedPhases append"
+else
+  fail "Phase 7: skip path missing storybookSkipped or non-append contract"
+fi
+
+if grep -Fq "visualQASkipped: true" "$PHASES_DIR/phase-8.5-design-review.md" &&
+   grep -Eq "visualQAMode: ['\"]skipped['\"]" "$PHASES_DIR/phase-8.5-design-review.md" &&
+   grep -Eq "Do NOT append.*phase-8\.5.*completedPhases" "$PHASES_DIR/phase-8.5-design-review.md"; then
+  pass "Phase 8.5: skip path records visual QA skip state without completedPhases append"
+else
+  fail "Phase 8.5: skip path missing visual QA skip-state contract"
+fi
+
+if grep -q 'integrationStatus: "skipped"' "$PHASES_DIR/phase-10-integration.md" &&
+   grep -Eq "Do NOT append.*phase-10.*completedPhases" "$PHASES_DIR/phase-10-integration.md"; then
+  pass "Phase 10: skip path records integrationStatus without completedPhases append"
+else
+  fail "Phase 10: skip path missing integration skip-state contract"
+fi
+
+if grep -q "storybookSkipped" "$DOCS_DIR/PHASE-INDEX.md" &&
+   grep -q "visualQASkipped" "$DOCS_DIR/PHASE-INDEX.md" &&
+   grep -q "integrationStatus" "$DOCS_DIR/PHASE-INDEX.md" &&
+   grep -q "visualQAMode" "$DOCS_DIR/PHASE-INDEX.md"; then
+  pass "PHASE-INDEX.md: documents optional skip-state fields"
+else
+  fail "PHASE-INDEX.md: missing optional skip-state field documentation"
+fi
+
+if grep -q "storybookSkipped" "$DOCS_DIR/QUALITY-GATES.md" &&
+   grep -q "visualQASkipped" "$DOCS_DIR/QUALITY-GATES.md" &&
+   grep -q "integrationStatus" "$DOCS_DIR/QUALITY-GATES.md" &&
+   grep -q "visualQAMode" "$DOCS_DIR/QUALITY-GATES.md"; then
+  pass "QUALITY-GATES.md: documents optional skip-state fields"
+else
+  fail "QUALITY-GATES.md: missing optional skip-state field documentation"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- align Phase 3.5 approval wording so text-only and preview-generated paths point to the correct gates before Phase 4
- document optional skip-state fields and non-append behavior consistently across the router, phase index, and quality gates
- tighten structural and semantic checks for skip-state contracts and end-of-file handoff/status validation

## Validation
- bash scripts/validate-skill-md.sh
- bash skills/design-farmer/tests/run-all.sh

## Issue
- closes #81