### PR TITLE
feat: add safe uninstall script and smoke coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,12 @@
   - `skills/design-farmer/tests/`: Test suites (`run-all.sh`, `test-semantic-consistency.sh`).
 - `scripts/`: Repository-level validation and CI scripts.
   - `scripts/validate-skill-md.sh`: Structural validation (phase files, router references, contracts).
-  - `scripts/test-install-smoke.sh`: Installer smoke tests across tools and shells.
+  - `scripts/test-install-smoke.sh`: Install/uninstall smoke tests across tools and shells.
 - `.github/`: GitHub configuration.
-  - `.github/workflows/skill-quality.yml`: CI pipeline (structural validation + install smoke tests).
+  - `.github/workflows/skill-quality.yml`: CI pipeline (structural validation + install/uninstall smoke tests).
   - `.github/pull_request_template.md`: PR template with validation evidence checklist.
 - `install.sh`: Automated installer (detects tools, supports selective target flags, downloads skill bundle atomically).
+- `uninstall.sh`: Automated uninstaller (detects/selects tools and removes only `skills/design-farmer` targets safely).
 - `AGENTS.md`: This file — repository-wide rules.
 - `CONTRIBUTING.md`: Contributor workflow (branch naming, commit convention, PR requirements).
 - `README.md`: Project overview, installation, and documentation links.
@@ -128,6 +129,6 @@ Repository-wide quality CI runs on every pull request and push to `main`.
 
 Jobs:
 - `validate-skill`: runs `bash scripts/validate-skill-md.sh` — fails if any structural check fails.
-- `install-smoke`: runs `bash scripts/test-install-smoke.sh` across 5 tools x 2 shells (bash, zsh) — fails if any installer smoke test fails.
+- `install-smoke`: runs `bash scripts/test-install-smoke.sh` across 5 tools x 2 shells (bash, zsh) — fails if any install/uninstall smoke test fails.
 
 All CI jobs must pass before a PR is merged.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -8,6 +8,12 @@ Run the installer script:
 curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash
 ```
 
+To remove the installed skill bundle, run the uninstaller script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash
+```
+
 The installer will:
 
 1. Detect supported local tools.
@@ -44,6 +50,33 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --dry-run
 ```
 
+### Uninstaller options
+
+```bash
+bash uninstall.sh [options]
+```
+
+- `--tool <name>`: uninstall only for a specific tool (repeatable)
+- `--all`: uninstall for all detected tools (default behavior)
+- `--interactive`: choose targets interactively (uses `fzf --multi` when available; otherwise numeric fallback)
+- `--dry-run`: show resolved targets without deleting files
+- `--list-tools`: show supported tools with detection status and exit
+
+Valid tool names: `claude`, `codex`, `amp`, `gemini`, `opencode`
+
+Examples:
+
+```bash
+# Uninstall only for Claude Code
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash -s -- --tool claude
+
+# Uninstall only for Codex and Gemini
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash -s -- --tool codex --tool gemini
+
+# Preview uninstall targets only
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash -s -- --dry-run
+```
+
 Supported tools:
 
 - Claude Code
@@ -72,5 +105,6 @@ Example tool roots:
 ## Troubleshooting
 
 - If installer output says `No supported tools detected`, install one supported tool first, then re-run.
+- If uninstaller output says `No supported tools detected. Nothing to uninstall.`, no supported local tool markers were found.
 - If a download fails, verify network access and check `curl --version`.
 - If you run `--interactive` in a non-TTY environment (for example CI), use `--tool` instead.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 
 The installer detects your tools, creates skill directories, and downloads the skill bundle. Supported tools: **Claude Code**, **Codex CLI**, **Amp**, **Gemini CLI**, **OpenCode**.
 
+To remove the skill bundle later:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash
+```
+
 Selective install examples:
 
 ```bash
@@ -68,7 +74,6 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 # Preview targets without writing files
 curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --dry-run
 ```
-
 For manual installation or troubleshooting, see [INSTALLATION.md](INSTALLATION.md).
 
 ## Documentation

--- a/docs/project-design-farmer.md
+++ b/docs/project-design-farmer.md
@@ -28,6 +28,7 @@ Before this project, agents had no repeatable workflow for:
 - Companion documentation (`PHASE-INDEX.md`, `QUALITY-GATES.md`, `MAINTENANCE.md`, `EXAMPLES-GALLERY.md`).
 - Greenfield reference example (`examples/DESIGN.md` — Nova UI).
 - Automated installer (`install.sh`) with atomic bundle deployment and selective target options (`--tool`, `--interactive`, `--dry-run`).
+- Automated uninstaller (`uninstall.sh`) with selective target options (`--tool`, `--interactive`, `--dry-run`) and safe path-guarded removal.
 - Structural validation script (`scripts/validate-skill-md.sh`).
 - Semantic consistency test suite (`tests/test-semantic-consistency.sh`).
 - CI pipeline (GitHub Actions: structural validation + install smoke tests).
@@ -151,6 +152,8 @@ Phase 0 (Preflight) ──→ detect topology, check DESIGN.md
 - [x] Exhaustive simulation (169 checks, 1152 paths) passes with zero failures.
 - [x] Installer deploys bundle atomically across 5 AI tools.
 - [x] Installer supports selective target installation (`--tool`, `--interactive`) and preview mode (`--dry-run`).
+- [x] Uninstaller safely removes only `*/skills/design-farmer` targets across 5 AI tools.
+- [x] Uninstaller supports selective target removal (`--tool`, `--interactive`) and preview mode (`--dry-run`).
 - [x] CI pipeline runs on every PR and push to `main`.
 - [x] DESIGN.md Config fields survive Phase 4.5 → Phase 0 round-trip (14 fields).
 - [x] Radius tone preference (`radiusTone`) is captured in discovery and propagated through re-entry/config templates.
@@ -183,3 +186,4 @@ Phase 0 (Preflight) ──→ detect topology, check DESIGN.md
 | 2026-04-09 | Codex | Updated re-entry contract to context-first flow and documented CI anti-drift guards |
 | 2026-04-09 | Codex | Added DESIGN.md source-classification decision to prevent false corruption handling for readable third-party docs |
 | 2026-04-09 | Codex | Added installer selective-target contract (`--tool`, `--interactive`, `--dry-run`) and acceptance criteria |
+| 2026-04-09 | Codex | Added uninstall script contract, safety scope, and install/uninstall smoke test expectations |

--- a/docs/project-uninstall-script.md
+++ b/docs/project-uninstall-script.md
@@ -1,0 +1,77 @@
+# project-uninstall-script
+
+## Summary
+
+Add a first-party `uninstall.sh` script that removes the `design-farmer` skill bundle from supported AI tool directories with the same target-selection ergonomics as `install.sh`, while enforcing strict path safety and no-op behavior for absent targets.
+
+## Evidence
+
+- The repository already ships `install.sh` with multi-tool detection, selective target flags, and `--dry-run`, but did not provide an official uninstall workflow.
+- Installation paths are deterministic and tool-specific, making a safe and explicit uninstall flow feasible.
+- Existing smoke coverage (`scripts/test-install-smoke.sh`) validated install behavior only, leaving uninstall behavior unverified.
+
+## Current Gap
+
+Users could install the bundle in one command but had no standardized uninstall path. Manual cleanup risks accidental deletion outside the intended `skills/design-farmer` directories and creates inconsistent support guidance.
+
+## Proposed Scope
+
+### In Scope
+
+- Add top-level `uninstall.sh` with option parity: `--tool`, `--all`, `--interactive`, `--dry-run`, `--list-tools`.
+- Reuse the same tool matrix and target directory mapping used by `install.sh`.
+- Delete only `*/skills/design-farmer` directories and preserve parent directories.
+- Add explicit safety checks for empty and unsafe paths.
+- Extend smoke tests to validate uninstall behavior and guardrails.
+- Update `README.md`, `INSTALLATION.md`, and repository policy/contracts that mention install lifecycle behavior.
+
+### Out of Scope
+
+- Deleting tool marker directories (e.g., `~/.claude`, `~/.agents`).
+- Removing any skill other than `design-farmer`.
+- Package-manager uninstall commands.
+
+## Architecture
+
+- `uninstall.sh` mirrors installer CLI parsing and selection flow:
+  - detect markers per supported tool
+  - resolve selected targets (`--tool`, `--all`, `--interactive`)
+  - print resolved targets with detection/install status
+  - honor `--dry-run` with no filesystem writes
+- Safety contract:
+  - target path must be non-empty
+  - target path must match `*/skills/design-farmer`
+  - no wildcard deletion
+  - absent targets are treated as no-op success
+- Validation contract:
+  - `scripts/test-install-smoke.sh` covers install and uninstall scenarios in isolated temp HOME fixtures.
+
+## Acceptance Criteria
+
+- [x] `uninstall.sh --tool <name>` removes only the selected tool target.
+- [x] `uninstall.sh --dry-run` reports selected targets and performs no deletion.
+- [x] `uninstall.sh` with absent bundle targets exits successfully and reports no-op behavior.
+- [x] `uninstall.sh` never deletes directories outside `*/skills/design-farmer`.
+- [x] Smoke tests include uninstall success/no-op/error paths.
+- [x] User-facing install docs include uninstall usage.
+
+## Dependencies
+
+- Existing tool marker and target path conventions defined in `install.sh`.
+- Smoke test harness under `scripts/test-install-smoke.sh`.
+- CI workflow that runs smoke tests across supported tools and shells.
+
+## Risks
+
+- **Risk:** Unsafe deletion if target path resolution drifts.
+  - **Mitigation:** Path guard enforces strict suffix validation before `rm -rf`.
+- **Risk:** Behavior divergence between installer and uninstaller options.
+  - **Mitigation:** Keep option surface and selection logic aligned; verify via smoke tests.
+- **Risk:** Confusion when tool markers are absent.
+  - **Mitigation:** Explicit no-op status messaging for "nothing to uninstall" cases.
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-04-09 | Codex | Initial draft |

--- a/scripts/test-install-smoke.sh
+++ b/scripts/test-install-smoke.sh
@@ -4,10 +4,16 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 INSTALLER="$ROOT_DIR/install.sh"
+UNINSTALLER="$ROOT_DIR/uninstall.sh"
 BASH_BIN="$(command -v bash)"
 
 if [[ ! -f "$INSTALLER" ]]; then
   echo "ERROR: Missing installer script: $INSTALLER"
+  exit 1
+fi
+
+if [[ ! -f "$UNINSTALLER" ]]; then
+  echo "ERROR: Missing uninstaller script: $UNINSTALLER"
   exit 1
 fi
 
@@ -428,6 +434,191 @@ test_atomic_install_preserves_existing_on_download_failure() {
   trap - RETURN
 }
 
+test_uninstall_removes_only_requested_target() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+  mkdir -p "$(tool_marker_path "codex" "$fake_home")"
+  write_curl_stub "$fake_bin"
+
+  local install_output="$temp_dir/install.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" BRANCH="smoke-test-branch" \
+    "$BASH_BIN" "$INSTALLER" --tool claude --tool codex >"$install_output" 2>&1
+
+  local claude_dir
+  claude_dir="$(installed_skill_dir_path "claude" "$fake_home")"
+  local codex_dir
+  codex_dir="$(installed_skill_dir_path "codex" "$fake_home")"
+
+  if [[ ! -d "$claude_dir" ]] || [[ ! -d "$codex_dir" ]]; then
+    echo "ERROR: Expected both claude and codex bundles to be installed before uninstall"
+    cat "$install_output"
+    exit 1
+  fi
+
+  local uninstall_output="$temp_dir/uninstall.log"
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$UNINSTALLER" --tool codex >"$uninstall_output" 2>&1
+
+  if [[ ! -d "$claude_dir" ]]; then
+    echo "ERROR: Uninstall removed unrequested claude target"
+    cat "$uninstall_output"
+    exit 1
+  fi
+
+  if [[ -d "$codex_dir" ]]; then
+    echo "ERROR: Uninstall did not remove requested codex target"
+    cat "$uninstall_output"
+    exit 1
+  fi
+
+  assert_contains "$uninstall_output" "Selected targets:"
+  assert_contains "$uninstall_output" "Codex CLI"
+  assert_contains "$uninstall_output" "Done!"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_uninstall_dry_run_does_not_delete_files() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+  write_curl_stub "$fake_bin"
+
+  local install_output="$temp_dir/install.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" BRANCH="smoke-test-branch" \
+    "$BASH_BIN" "$INSTALLER" --tool claude >"$install_output" 2>&1
+
+  local claude_dir
+  claude_dir="$(installed_skill_dir_path "claude" "$fake_home")"
+  if [[ ! -d "$claude_dir" ]]; then
+    echo "ERROR: Precondition failed; claude install target missing"
+    cat "$install_output"
+    exit 1
+  fi
+
+  local uninstall_output="$temp_dir/uninstall.log"
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$UNINSTALLER" --tool claude --dry-run >"$uninstall_output" 2>&1
+
+  if [[ ! -d "$claude_dir" ]]; then
+    echo "ERROR: uninstall dry-run should not delete installed target"
+    cat "$uninstall_output"
+    exit 1
+  fi
+
+  assert_contains "$uninstall_output" "Dry run"
+  assert_contains "$uninstall_output" "Done (dry run)."
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_uninstall_absent_target_is_noop_success() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/uninstall.log"
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$UNINSTALLER" --tool claude >"$output_file" 2>&1
+
+  assert_contains "$output_file" "already absent"
+  assert_contains "$output_file" "Done!"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_uninstall_no_detected_tools_is_noop_success() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  mkdir -p "$fake_home"
+
+  local output_file="$temp_dir/uninstall.log"
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$UNINSTALLER" >"$output_file" 2>&1
+
+  assert_contains "$output_file" "No supported tools detected. Nothing to uninstall."
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_uninstall_conflicting_flags_fail() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/output.log"
+  set +e
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$UNINSTALLER" --all --tool claude >"$output_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "ERROR: Uninstaller should fail for conflicting flags"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "--all cannot be combined with --tool"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_uninstall_interactive_requires_terminal() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+
+  local output_file="$temp_dir/output.log"
+  set +e
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$UNINSTALLER" --interactive >"$output_file" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "ERROR: Uninstaller should fail for --interactive without TTY"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "--interactive requires an interactive terminal"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
 main() {
   local tool="${1:-}"
   if [[ -z "$tool" ]]; then
@@ -468,7 +659,25 @@ main() {
   echo "[smoke] failure path: download error preserves existing bundle"
   test_atomic_install_preserves_existing_on_download_failure
 
-  echo "All installer smoke tests passed for tool=$tool"
+  echo "[smoke] uninstall path: --tool removes only requested target"
+  test_uninstall_removes_only_requested_target
+
+  echo "[smoke] uninstall path: --dry-run does not delete files"
+  test_uninstall_dry_run_does_not_delete_files
+
+  echo "[smoke] uninstall path: absent target is noop success"
+  test_uninstall_absent_target_is_noop_success
+
+  echo "[smoke] uninstall path: no detected tools is noop success"
+  test_uninstall_no_detected_tools_is_noop_success
+
+  echo "[smoke] uninstall parser path: conflicting flags fail"
+  test_uninstall_conflicting_flags_fail
+
+  echo "[smoke] uninstall interactive path: requires terminal in CI"
+  test_uninstall_interactive_requires_terminal
+
+  echo "All install/uninstall smoke tests passed for tool=$tool"
 }
 
 main "$@"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILL_NAME="design-farmer"
+
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  YELLOW='\033[0;33m'
+  RESET='\033[0m'
+else
+  BOLD=''
+  GREEN=''
+  RED=''
+  YELLOW=''
+  RESET=''
+fi
+
+tool_marker() {
+  case "$1" in
+    claude) echo "${HOME}/.claude" ;;
+    codex) echo "${HOME}/.agents" ;;
+    amp) echo "${HOME}/.config/agents" ;;
+    gemini) echo "${HOME}/.gemini" ;;
+    opencode) echo "${HOME}/.config/opencode" ;;
+  esac
+}
+
+tool_skill_dir() {
+  case "$1" in
+    claude) echo "${HOME}/.claude/skills/${SKILL_NAME}" ;;
+    codex) echo "${HOME}/.agents/skills/${SKILL_NAME}" ;;
+    amp) echo "${HOME}/.config/agents/skills/${SKILL_NAME}" ;;
+    gemini) echo "${HOME}/.gemini/skills/${SKILL_NAME}" ;;
+    opencode) echo "${HOME}/.config/opencode/skills/${SKILL_NAME}" ;;
+  esac
+}
+
+tool_label() {
+  case "$1" in
+    claude) echo "Claude Code" ;;
+    codex) echo "Codex CLI" ;;
+    amp) echo "Amp" ;;
+    gemini) echo "Gemini CLI" ;;
+    opencode) echo "OpenCode" ;;
+  esac
+}
+
+is_supported_tool() {
+  local candidate="$1"
+  local tool
+  for tool in "${TOOLS[@]}"; do
+    if [ "$tool" = "$candidate" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+print_usage() {
+  cat <<'EOF'
+Usage: uninstall.sh [options]
+
+Options:
+  --tool <name>     Uninstall only for the given tool (repeatable)
+                    Valid: claude, codex, amp, gemini, opencode
+  --all             Uninstall for all detected tools (default behavior)
+  --interactive     Select uninstall targets interactively
+  --dry-run         Show resolved uninstall targets without deleting files
+  --list-tools      List supported tools and detected status, then exit
+  -h, --help        Show this help message
+EOF
+}
+
+list_tools() {
+  local tool
+  printf "%bSupported tools%b\n" "$BOLD" "$RESET"
+  for tool in "${TOOLS[@]}"; do
+    local marker
+    local status="not detected"
+    marker="$(tool_marker "$tool")"
+    if [ -d "$marker" ]; then
+      status="detected"
+    fi
+    printf "  - %-8s %-12s %s\n" "$tool" "[$status]" "$marker"
+  done
+}
+
+append_unique_tool() {
+  local candidate="$1"
+  local existing
+  for existing in "${SELECTED[@]}"; do
+    if [ "$existing" = "$candidate" ]; then
+      return 0
+    fi
+  done
+  SELECTED+=("$candidate")
+}
+
+select_interactively() {
+  if [ "${#DETECTED[@]}" -eq 0 ]; then
+    printf "%bError:%b --interactive requires at least one detected tool.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+
+  if [ ! -t 1 ] || [ ! -r /dev/tty ]; then
+    printf "%bError:%b --interactive requires an interactive terminal.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+
+  printf "%bInteractive target selection%b\n" "$BOLD" "$RESET"
+
+  if command -v fzf >/dev/null 2>&1; then
+    printf "Use Space to toggle, Enter to confirm.\n\n"
+    local chosen=()
+    local picked
+    while IFS= read -r picked; do
+      chosen+=("$picked")
+    done < <(printf "%s\n" "${DETECTED[@]}" | fzf --multi --prompt "Select uninstall targets > " --height 40% --border --layout=reverse)
+
+    if [ "${#chosen[@]}" -eq 0 ]; then
+      printf "%bError:%b no tools selected.\n" "$RED" "$RESET" >&2
+      exit 1
+    fi
+
+    SELECTED=("${chosen[@]}")
+    return 0
+  fi
+
+  printf "fzf not found. Falling back to numeric selection.\n"
+  printf "Enter comma-separated numbers (example: 1,3).\n\n"
+
+  local i=1
+  local tool
+  for tool in "${DETECTED[@]}"; do
+    printf "  %d) %s\n" "$i" "$(tool_label "$tool")"
+    i=$((i + 1))
+  done
+
+  printf "\nSelection: "
+  local raw_input
+  IFS= read -r raw_input </dev/tty
+  if [ -z "$raw_input" ]; then
+    printf "%bError:%b no tools selected.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+
+  local parts
+  IFS=',' read -r -a parts <<<"$raw_input"
+  local part
+  for part in "${parts[@]}"; do
+    local idx
+    idx="${part//[[:space:]]/}"
+
+    if [[ ! "$idx" =~ ^[0-9]+$ ]]; then
+      printf "%bError:%b invalid selection '%s'.\n" "$RED" "$RESET" "$part" >&2
+      exit 1
+    fi
+    if [ "$idx" -lt 1 ] || [ "$idx" -gt "${#DETECTED[@]}" ]; then
+      printf "%bError:%b selection out of range: %s.\n" "$RED" "$RESET" "$idx" >&2
+      exit 1
+    fi
+
+    append_unique_tool "${DETECTED[$((idx - 1))]}"
+  done
+
+  if [ "${#SELECTED[@]}" -eq 0 ]; then
+    printf "%bError:%b no tools selected.\n" "$RED" "$RESET" >&2
+    exit 1
+  fi
+}
+
+safe_remove_target() {
+  local target_dir="$1"
+
+  if [ -z "$target_dir" ]; then
+    printf "%bError:%b refusing empty target path.\n" "$RED" "$RESET" >&2
+    return 1
+  fi
+
+  case "$target_dir" in
+    */skills/design-farmer) ;;
+    *)
+      printf "%bError:%b refusing unsafe path: %s\n" "$RED" "$RESET" "$target_dir" >&2
+      return 1
+      ;;
+  esac
+
+  if [ ! -e "$target_dir" ]; then
+    return 0
+  fi
+
+  rm -rf "$target_dir"
+  return 0
+}
+
+TOOLS=(claude codex amp gemini opencode)
+DETECTED=()
+REQUESTED_TOOLS=()
+SELECTED=()
+USE_ALL=0
+INTERACTIVE=0
+DRY_RUN=0
+LIST_ONLY=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tool)
+      if [ "$#" -lt 2 ]; then
+        printf "%bError:%b --tool requires a value.\n" "$RED" "$RESET" >&2
+        exit 1
+      fi
+      REQUESTED_TOOLS+=("$2")
+      shift 2
+      ;;
+    --all)
+      USE_ALL=1
+      shift
+      ;;
+    --interactive)
+      INTERACTIVE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --list-tools)
+      LIST_ONLY=1
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      printf "%bError:%b unknown option: %s\n\n" "$RED" "$RESET" "$1" >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+  for tool in "${TOOLS[@]}"; do
+    marker="$(tool_marker "$tool")"
+    if [ -d "$marker" ]; then
+      DETECTED+=("$tool")
+    fi
+  done
+  list_tools
+  exit 0
+fi
+
+if [ "$INTERACTIVE" -eq 1 ] && [ "${#REQUESTED_TOOLS[@]}" -gt 0 ]; then
+  printf "%bError:%b --interactive cannot be combined with --tool.\n" "$RED" "$RESET" >&2
+  exit 1
+fi
+
+if [ "$INTERACTIVE" -eq 1 ] && [ "$USE_ALL" -eq 1 ]; then
+  printf "%bError:%b --interactive cannot be combined with --all.\n" "$RED" "$RESET" >&2
+  exit 1
+fi
+
+if [ "$USE_ALL" -eq 1 ] && [ "${#REQUESTED_TOOLS[@]}" -gt 0 ]; then
+  printf "%bError:%b --all cannot be combined with --tool.\n" "$RED" "$RESET" >&2
+  exit 1
+fi
+
+for tool in "${TOOLS[@]}"; do
+  marker="$(tool_marker "$tool")"
+  if [ -d "$marker" ]; then
+    DETECTED+=("$tool")
+  fi
+done
+
+printf "%bUninstalling design-farmer skill%b\n\n" "$BOLD" "$RESET"
+
+if [ "$INTERACTIVE" -eq 1 ]; then
+  select_interactively
+elif [ "${#REQUESTED_TOOLS[@]}" -gt 0 ]; then
+  for tool in "${REQUESTED_TOOLS[@]}"; do
+    if ! is_supported_tool "$tool"; then
+      printf "%bError:%b unsupported tool '%s'.\n" "$RED" "$RESET" "$tool" >&2
+      print_usage >&2
+      exit 1
+    fi
+    append_unique_tool "$tool"
+  done
+elif [ "$USE_ALL" -eq 1 ] || [ "${#REQUESTED_TOOLS[@]}" -eq 0 ]; then
+  SELECTED=("${DETECTED[@]}")
+fi
+
+if [ "$DRY_RUN" -eq 1 ] && [ "${#REQUESTED_TOOLS[@]}" -eq 0 ] && [ "$INTERACTIVE" -eq 0 ] && [ "${#SELECTED[@]}" -eq 0 ]; then
+  printf "%bDry run%b — no files will be deleted.\n\n" "$BOLD" "$RESET"
+  printf "No supported tools detected. Nothing to uninstall.\n"
+  printf "%bDone (dry run).%b\n" "$GREEN" "$RESET"
+  exit 0
+fi
+
+if [ "${#SELECTED[@]}" -eq 0 ]; then
+  printf "%bNo supported tools detected. Nothing to uninstall.%b\n" "$YELLOW" "$RESET"
+  exit 0
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf "%bDry run%b — no files will be deleted.\n\n" "$BOLD" "$RESET"
+fi
+
+printf "Selected targets:\n"
+for tool in "${SELECTED[@]}"; do
+  target_dir="$(tool_skill_dir "$tool")"
+  marker="$(tool_marker "$tool")"
+  detected_status="detected"
+  install_status="installed"
+
+  if [ ! -d "$marker" ]; then
+    detected_status="not detected"
+  fi
+  if [ ! -d "$target_dir" ]; then
+    install_status="absent"
+  fi
+
+  printf "  - %s (%s, %s) -> %s\n" "$(tool_label "$tool")" "$detected_status" "$install_status" "$target_dir"
+done
+printf "\n"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf "%bDone (dry run).%b\n" "$GREEN" "$RESET"
+  exit 0
+fi
+
+FAILED=0
+
+for tool in "${SELECTED[@]}"; do
+  target_dir="$(tool_skill_dir "$tool")"
+  label="$(tool_label "$tool")"
+
+  if [ -d "$target_dir" ]; then
+    if safe_remove_target "$target_dir"; then
+      printf "  %b✓%b %s\n" "$GREEN" "$RESET" "$label"
+    else
+      printf "  %b✗%b %s (uninstall failed)\n" "$RED" "$RESET" "$label"
+      FAILED=1
+    fi
+  else
+    printf "  %b-%b %s (already absent)\n" "$YELLOW" "$RESET" "$label"
+  fi
+done
+
+printf "\n"
+
+if [ "$FAILED" -ne 0 ]; then
+  printf "%bCompleted with errors.%b\n" "$YELLOW" "$RESET"
+  exit 1
+fi
+
+printf "%bDone!%b\n" "$GREEN" "$RESET"


### PR DESCRIPTION
## Summary
- add a top-level `uninstall.sh` with option parity to `install.sh` (`--tool`, `--all`, `--interactive`, `--dry-run`, `--list-tools`)
- enforce uninstall safety by deleting only validated `*/skills/design-farmer` targets and treating absent targets as explicit no-op success
- extend install smoke coverage to validate uninstall behavior and update repository/docs contracts for install+uninstall lifecycle

## Validation
- `bash -n uninstall.sh && bash -n scripts/test-install-smoke.sh`
- `for tool in claude codex amp gemini opencode; do bash scripts/test-install-smoke.sh \"$tool\"; done`
- `bash skills/design-farmer/tests/run-all.sh`
- `bash scripts/validate-skill-md.sh`