### PR TITLE
docs: align README install-first flow and streamline uninstall guidance

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -7,12 +7,7 @@ Run the installer script:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash
 ```
-
-To remove the installed skill bundle, run the uninstaller script:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash
-```
+If you need to remove the bundle later, see [Uninstall options](#uninstall-options).
 
 The installer will:
 
@@ -50,7 +45,9 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/install.sh | bash -s -- --dry-run
 ```
 
-### Uninstaller options
+### Uninstall options
+
+`uninstall.sh` mirrors the installer surface (`--tool`, `--all`, `--interactive`, `--dry-run`, `--list-tools`) and only removes `*/skills/design-farmer` targets.
 
 ```bash
 bash uninstall.sh [options]

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,6 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 ```
 
 インストーラが利用中のツールを検出し、スキルディレクトリの作成とバンドルのダウンロードを行います。対応ツール：**Claude Code**、**Codex CLI**、**Amp**、**Gemini CLI**、**OpenCode**。
+アンインストール（任意）：`curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash`（全オプションは [INSTALLATION.md](INSTALLATION.md) を参照）。
 
 手動インストールやトラブルシューティングは[INSTALLATION.md](INSTALLATION.md)を参照してください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -55,6 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 ```
 
 설치 스크립트가 사용 중인 도구를 감지하고, 스킬 디렉토리를 만들고, 번들을 내려받습니다. 지원 도구: **Claude Code**, **Codex CLI**, **Amp**, **Gemini CLI**, **OpenCode**.
+삭제(선택): `curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash` (옵션 전체는 [INSTALLATION.md](INSTALLATION.md) 참고).
 
 수동 설치 및 문제 해결은 [INSTALLATION.md](INSTALLATION.md)를 참고하세요.
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 ```
 
 The installer detects your tools, creates skill directories, and downloads the skill bundle. Supported tools: **Claude Code**, **Codex CLI**, **Amp**, **Gemini CLI**, **OpenCode**.
-
-To remove the skill bundle later:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash
-```
+Uninstall (optional): `curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash` (full options in [INSTALLATION.md](INSTALLATION.md)).
 
 Selective install examples:
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -55,6 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 ```
 
 安裝腳本會自動偵測已安裝的工具，建立技能目錄並下載技能包。支援的工具：**Claude Code**、**Codex CLI**、**Amp**、**Gemini CLI**、**OpenCode**。
+解除安裝（可選）：`curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash`（完整選項見 [INSTALLATION.md](INSTALLATION.md)）。
 
 手動安裝及問題排查請參閱 [INSTALLATION.md](INSTALLATION.md)。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,6 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/inst
 ```
 
 安装脚本会自动检测已安装的工具，创建技能目录并下载技能包。支持的工具：**Claude Code**、**Codex CLI**、**Amp**、**Gemini CLI**、**OpenCode**。
+卸载（可选）：`curl -fsSL https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/uninstall.sh | bash`（完整选项见 [INSTALLATION.md](INSTALLATION.md)）。
 
 手动安装及问题排查请参阅 [INSTALLATION.md](INSTALLATION.md)。
 

--- a/docs/project-design-farmer.md
+++ b/docs/project-design-farmer.md
@@ -29,6 +29,7 @@ Before this project, agents had no repeatable workflow for:
 - Greenfield reference example (`examples/DESIGN.md` — Nova UI).
 - Automated installer (`install.sh`) with atomic bundle deployment and selective target options (`--tool`, `--interactive`, `--dry-run`).
 - Automated uninstaller (`uninstall.sh`) with selective target options (`--tool`, `--interactive`, `--dry-run`) and safe path-guarded removal.
+- README and localized README variants aligned to an install-first flow, with uninstall guidance limited to a single-line pointer to `uninstall.sh` and `INSTALLATION.md` for full options.
 - Structural validation script (`scripts/validate-skill-md.sh`).
 - Semantic consistency test suite (`tests/test-semantic-consistency.sh`).
 - CI pipeline (GitHub Actions: structural validation + install smoke tests).
@@ -154,6 +155,7 @@ Phase 0 (Preflight) ──→ detect topology, check DESIGN.md
 - [x] Installer supports selective target installation (`--tool`, `--interactive`) and preview mode (`--dry-run`).
 - [x] Uninstaller safely removes only `*/skills/design-farmer` targets across 5 AI tools.
 - [x] Uninstaller supports selective target removal (`--tool`, `--interactive`) and preview mode (`--dry-run`).
+- [x] README + localized README files keep install as the primary path and present uninstall as a single-line optional action.
 - [x] CI pipeline runs on every PR and push to `main`.
 - [x] DESIGN.md Config fields survive Phase 4.5 → Phase 0 round-trip (14 fields).
 - [x] Radius tone preference (`radiusTone`) is captured in discovery and propagated through re-entry/config templates.
@@ -187,3 +189,4 @@ Phase 0 (Preflight) ──→ detect topology, check DESIGN.md
 | 2026-04-09 | Codex | Added DESIGN.md source-classification decision to prevent false corruption handling for readable third-party docs |
 | 2026-04-09 | Codex | Added installer selective-target contract (`--tool`, `--interactive`, `--dry-run`) and acceptance criteria |
 | 2026-04-09 | Codex | Added uninstall script contract, safety scope, and install/uninstall smoke test expectations |
+| 2026-04-09 | Codex | Aligned README and localized README install-first messaging with one-line uninstall guidance |

--- a/docs/project-uninstall-script.md
+++ b/docs/project-uninstall-script.md
@@ -23,7 +23,8 @@ Users could install the bundle in one command but had no standardized uninstall 
 - Delete only `*/skills/design-farmer` directories and preserve parent directories.
 - Add explicit safety checks for empty and unsafe paths.
 - Extend smoke tests to validate uninstall behavior and guardrails.
-- Update `README.md`, `INSTALLATION.md`, and repository policy/contracts that mention install lifecycle behavior.
+- Keep `README.md` and localized README files install-first, with uninstall shown as a single-line optional command.
+- Keep full uninstall option details in `INSTALLATION.md` and repository policy/contracts that mention install lifecycle behavior.
 
 ### Out of Scope
 
@@ -45,6 +46,9 @@ Users could install the bundle in one command but had no standardized uninstall 
   - absent targets are treated as no-op success
 - Validation contract:
   - `scripts/test-install-smoke.sh` covers install and uninstall scenarios in isolated temp HOME fixtures.
+- Documentation contract:
+  - README files expose uninstall as one-line optional guidance.
+  - `INSTALLATION.md` is the canonical uninstall option reference.
 
 ## Acceptance Criteria
 
@@ -75,3 +79,4 @@ Users could install the bundle in one command but had no standardized uninstall 
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-09 | Codex | Initial draft |
+| 2026-04-09 | Codex | Clarified install-first README guidance and canonical uninstall detail location |


### PR DESCRIPTION
## Summary
- Align all README variants (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh.md`, `README.zh-TW.md`) to keep installation as the primary path and reduce uninstall to a single optional line.
- Remove the prominent uninstall code block from `README.md` and replace it with one-line guidance that points to `INSTALLATION.md` for full options.
- Update `INSTALLATION.md` and project docs (`docs/project-design-farmer.md`, `docs/project-uninstall-script.md`) so install/uninstall messaging is consistent and install-first.

## Validation
- `bash scripts/validate-skill-md.sh`
- `bash skills/design-farmer/tests/run-all.sh`