### PR TITLE
chore: prepare design-farmer 0.0.6 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 # AI / Agent
 .omc/
 .claude/
+.sisyphus/
 state/
 
 # Dependencies

--- a/skills/design-farmer/SKILL.md
+++ b/skills/design-farmer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-farmer
-version: 0.0.5
+version: 0.0.6
 description: |
   Automated design system construction from repository analysis to production-ready implementation.
   Analyzes codebases, extracts design patterns, builds token hierarchies with OKLCH color management,


### PR DESCRIPTION
## Summary
- ignore local `.sisyphus/` workspace state in git
- bump the Design Farmer skill version from `0.0.5` to `0.0.6`
- keep the release prep scoped to the canonical skill metadata file