### PR TITLE
fix: query GitHub Releases API in version-check to stop promoting unreleased tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
   - `skills/design-farmer/docs/`: Companion docs (`PHASE-INDEX.md`, `QUALITY-GATES.md`, `MAINTENANCE.md`, `EXAMPLES-GALLERY.md`).
   - `skills/design-farmer/examples/`: Reference examples (`DESIGN.md` — Nova UI greenfield reference).
   - `skills/design-farmer/bin/`: Executable utilities (`version-check`).
-  - `skills/design-farmer/tests/`: Test suites (`run-all.sh`, `test-semantic-consistency.sh`).
+  - `skills/design-farmer/tests/`: Test suites (`run-all.sh`, `test-semantic-consistency.sh`, `test-version-check.sh`).
 - `scripts/`: Repository-level validation and CI scripts.
   - `scripts/validate-skill-md.sh`: Structural validation (phase files, router references, contracts).
   - `scripts/release.sh`: Atomic release automation (version bump, file sync, tag creation).
@@ -104,9 +104,11 @@ When asked to review comments on a GitHub PR:
 ### Testing Rules
 
 - All test suites MUST pass before a PR is merged.
-- Two test suites exist:
+- Three test suites exist:
   1. **Structural validation** (`scripts/validate-skill-md.sh`): phase file existence, router references, orphan detection, completion status protocol, cross-phase contracts, discovery interview gating, tool-contract keywords.
   2. **Semantic consistency** (`skills/design-farmer/tests/test-semantic-consistency.sh`): cross-reference section numbers, config field coverage, phase flow sequence, status message completeness, handoff chain, docs alignment, Fix Loop Protocol coverage, Phase 0 re-entry paths, conditional question gates, Phase 4b light-only guard, Phase 6 non-React guardrail, cross-phase data dependencies, pipeline state tracking.
+  3. **version-check behavior** (`skills/design-farmer/tests/test-version-check.sh`): Releases API primary path, SKILL.md-on-main fallback path, and silent exit when both upstream sources are unreachable — uses `file://` URL overrides so the suite runs offline.
+- All three suites are run together by `skills/design-farmer/tests/run-all.sh`.
 - When adding a new phase, branching condition, or config field, add corresponding test coverage in the appropriate suite.
 
 ### Commit Convention

--- a/skills/design-farmer/bin/version-check
+++ b/skills/design-farmer/bin/version-check
@@ -5,7 +5,16 @@ set -euo pipefail
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CACHE_DIR="${HOME}/.config/design-farmer"
 CACHE_FILE="${CACHE_DIR}/version-check.cache"
-REMOTE_URL="https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/skills/design-farmer/SKILL.md"
+
+# Primary upstream source: the GitHub Releases API returns the latest tagged
+# release, so users are only ever prompted to upgrade to a version that is
+# actually published. Overridable via environment variable for tests.
+: "${DF_RELEASES_API_URL:=https://api.github.com/repos/ohprettyhak/design-farmer/releases/latest}"
+
+# Fallback source: SKILL.md on main. Used only when the Releases API is
+# unreachable or rate-limited so offline users retain best-effort checks,
+# at the cost of occasionally prompting for a main-ahead-of-tag version.
+: "${DF_FALLBACK_RAW_URL:=https://raw.githubusercontent.com/ohprettyhak/design-farmer/main/skills/design-farmer/SKILL.md}"
 
 TTL_OK=3600
 TTL_UPGRADE=43200
@@ -46,10 +55,36 @@ if [[ -f "$CACHE_FILE" ]]; then
   fi
 fi
 
-REMOTE_RAW=$(curl -fsSL --max-time 5 "$REMOTE_URL" 2>/dev/null || echo "")
-REMOTE_VERSION=$(echo "$REMOTE_RAW" | sed -n 's/^version:[[:space:]]*//p' | head -1 | tr -d '[:space:]')
+REMOTE_VERSION=""
 
-if [[ -z "$REMOTE_VERSION" ]] || [[ ! "$REMOTE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# Primary path: query the Releases API, extract tag_name without jq so the
+# bundle runs in plain shell environments, strip the leading 'v', and accept
+# only strict semver.
+#
+# The `|| true` suffix on the pipeline keeps a no-match grep from tripping
+# `set -o pipefail` and aborting the whole script before the fallback can run.
+RELEASES_RAW=$(curl -fsSL --max-time 5 -H "Accept: application/vnd.github+json" "$DF_RELEASES_API_URL" 2>/dev/null || echo "")
+if [[ -n "$RELEASES_RAW" ]]; then
+  RELEASE_TAG=$(echo "$RELEASES_RAW" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | head -1 | sed -E 's/.*"([^"]*)"$/\1/' || true)
+  CANDIDATE=${RELEASE_TAG#v}
+  if [[ -n "$CANDIDATE" ]] && [[ "$CANDIDATE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    REMOTE_VERSION="$CANDIDATE"
+  fi
+fi
+
+# Fallback path: if the Releases API was unreachable, rate-limited, or
+# returned a tag that did not parse as strict semver, fall back to the
+# SKILL.md frontmatter on main so offline users still get a best-effort
+# check. This retains the pre-#94 behavior under degraded conditions.
+if [[ -z "$REMOTE_VERSION" ]]; then
+  FALLBACK_RAW=$(curl -fsSL --max-time 5 "$DF_FALLBACK_RAW_URL" 2>/dev/null || echo "")
+  CANDIDATE=$(echo "$FALLBACK_RAW" | sed -n 's/^version:[[:space:]]*//p' | head -1 | tr -d '[:space:]' || true)
+  if [[ -n "$CANDIDATE" ]] && [[ "$CANDIDATE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    REMOTE_VERSION="$CANDIDATE"
+  fi
+fi
+
+if [[ -z "$REMOTE_VERSION" ]]; then
   exit 0
 fi
 

--- a/skills/design-farmer/tests/run-all.sh
+++ b/skills/design-farmer/tests/run-all.sh
@@ -18,6 +18,11 @@
 #      - Cross-phase data dependencies, pipeline state tracking
 #      - Fix Loop Protocol coverage
 #
+#   3. version-check behavior (tests/test-version-check.sh)
+#      - Releases API primary path (UPGRADE_AVAILABLE / OK)
+#      - Fallback to SKILL.md on main when Releases API is unreachable
+#      - Silent exit when both upstream sources fail
+#
 # Usage: bash skills/design-farmer/tests/run-all.sh
 
 set -eo pipefail
@@ -52,6 +57,18 @@ if bash "$TESTS_DIR/test-semantic-consistency.sh"; then
 else
   echo ""
   echo "Suite 2: FAILED"
+  SUITE_FAIL=1
+fi
+
+echo ""
+echo "── Suite 3: version-check Behavior ──"
+echo ""
+if bash "$TESTS_DIR/test-version-check.sh"; then
+  echo ""
+  echo "Suite 3: PASSED"
+else
+  echo ""
+  echo "Suite 3: FAILED"
   SUITE_FAIL=1
 fi
 

--- a/skills/design-farmer/tests/test-version-check.sh
+++ b/skills/design-farmer/tests/test-version-check.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Behavioral smoke tests for bin/version-check.
+#
+# Covers:
+#   - Primary path (Releases API) reports UPGRADE_AVAILABLE for a newer tag
+#   - Primary path returns OK when the tag matches the local version
+#   - Primary path returns OK when the local version is ahead of the tag
+#   - Malformed / empty Releases API response falls back to main SKILL.md
+#   - Both sources unreachable exits silently
+#
+# Usage: bash skills/design-farmer/tests/test-version-check.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+REAL_SCRIPT="${REPO_ROOT}/skills/design-farmer/bin/version-check"
+
+if [[ ! -x "$REAL_SCRIPT" ]]; then
+  echo "version-check script missing or not executable at $REAL_SCRIPT" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+setup_sandbox() {
+  SANDBOX=$(mktemp -d)
+  # Fake skill bundle layout
+  mkdir -p "${SANDBOX}/skill/bin" "${SANDBOX}/home"
+  cp "$REAL_SCRIPT" "${SANDBOX}/skill/bin/version-check"
+  chmod +x "${SANDBOX}/skill/bin/version-check"
+  cat > "${SANDBOX}/skill/SKILL.md" <<'SKILL_EOF'
+---
+name: design-farmer
+version: 0.0.6
+description: test skill
+---
+
+# Test skill
+SKILL_EOF
+  export HOME="${SANDBOX}/home"
+}
+
+teardown_sandbox() {
+  if [[ -n "${SANDBOX:-}" ]] && [[ -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+  unset SANDBOX
+}
+
+run_check() {
+  # Run the sandboxed copy of version-check, isolating HOME and passing URL
+  # overrides. Returns stdout so tests can assert on format.
+  "${SANDBOX}/skill/bin/version-check" 2>/dev/null || true
+}
+
+assert_output() {
+  local label=$1
+  local expected=$2
+  local actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    got:      '$actual'"
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$label")
+  fi
+}
+
+echo "=== version-check behavioral tests ==="
+echo ""
+
+# Test 1: Primary path, newer release tag → UPGRADE_AVAILABLE
+echo "Test 1: Primary path reports UPGRADE_AVAILABLE for a newer tag"
+setup_sandbox
+cat > "${SANDBOX}/release.json" <<'EOF'
+{"tag_name":"v9.9.9","name":"Release 9.9.9","draft":false,"prerelease":false}
+EOF
+out=$(DF_RELEASES_API_URL="file://${SANDBOX}/release.json" DF_FALLBACK_RAW_URL="file://${SANDBOX}/does-not-exist" run_check)
+assert_output "primary newer tag → UPGRADE_AVAILABLE 0.0.6 9.9.9" "UPGRADE_AVAILABLE 0.0.6 9.9.9" "$out"
+teardown_sandbox
+
+# Test 2: Primary path, tag equals local → silent OK
+echo "Test 2: Primary path is silent when tag matches local version"
+setup_sandbox
+cat > "${SANDBOX}/release.json" <<'EOF'
+{"tag_name":"v0.0.6","name":"Release 0.0.6"}
+EOF
+out=$(DF_RELEASES_API_URL="file://${SANDBOX}/release.json" DF_FALLBACK_RAW_URL="file://${SANDBOX}/does-not-exist" run_check)
+assert_output "primary equal tag → silent" "" "$out"
+teardown_sandbox
+
+# Test 3: Primary path, tag older than local → silent OK
+echo "Test 3: Primary path is silent when local is ahead of the released tag"
+setup_sandbox
+cat > "${SANDBOX}/release.json" <<'EOF'
+{"tag_name":"v0.0.1","name":"Release 0.0.1"}
+EOF
+out=$(DF_RELEASES_API_URL="file://${SANDBOX}/release.json" DF_FALLBACK_RAW_URL="file://${SANDBOX}/does-not-exist" run_check)
+assert_output "primary older tag → silent" "" "$out"
+teardown_sandbox
+
+# Test 4: Malformed Releases API response falls back to main SKILL.md
+echo "Test 4: Malformed Releases API response falls back to main SKILL.md"
+setup_sandbox
+printf '%s\n' '<html>403 rate-limited</html>' > "${SANDBOX}/release.json"
+cat > "${SANDBOX}/main-skill.md" <<'EOF'
+---
+name: design-farmer
+version: 9.9.9
+description: main ahead of tag
+---
+EOF
+out=$(DF_RELEASES_API_URL="file://${SANDBOX}/release.json" DF_FALLBACK_RAW_URL="file://${SANDBOX}/main-skill.md" run_check)
+assert_output "malformed API → fallback to main → UPGRADE_AVAILABLE 0.0.6 9.9.9" "UPGRADE_AVAILABLE 0.0.6 9.9.9" "$out"
+teardown_sandbox
+
+# Test 5: Both sources unreachable → silent exit
+echo "Test 5: Both sources unreachable exits silently"
+setup_sandbox
+out=$(DF_RELEASES_API_URL="file://${SANDBOX}/missing-a" DF_FALLBACK_RAW_URL="file://${SANDBOX}/missing-b" run_check)
+assert_output "both missing → silent" "" "$out"
+teardown_sandbox
+
+echo ""
+echo "==========================================="
+echo "RESULTS: ${PASS} passed, ${FAIL} failed"
+echo "==========================================="
+
+if (( FAIL > 0 )); then
+  echo "Failed tests:"
+  for name in "${FAILED_TESTS[@]}"; do
+    echo "  - $name"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Closes #94.

`skills/design-farmer/bin/version-check` previously fetched `SKILL.md` from the `main` branch, so the moment any commit bumped the frontmatter version, every installed user saw an `UPGRADE_AVAILABLE` prompt — even before the matching release tag was pushed. Marketplace users were especially affected because marketplace plugins are pinned to tags, so the prompt pointed them at a version their channel could not yet serve.

Switch the primary upstream query to the GitHub Releases API and treat the previous `main`-based fetch as a best-effort fallback only.

## Changes

- **`skills/design-farmer/bin/version-check`**
  - Primary: `https://api.github.com/repos/ohprettyhak/design-farmer/releases/latest`, extract `tag_name` without `jq`, strip the leading `v`, accept strict `X.Y.Z`.
  - Fallback: the previous raw `main` fetch, used only when the Releases API is unreachable, rate-limited, or returns a non-semver tag.
  - Both URLs are overridable via `DF_RELEASES_API_URL` / `DF_FALLBACK_RAW_URL` for tests.
  - Added `|| true` on the grep pipeline so `set -o pipefail` does not kill the script when the primary path has no match — this was a live bug that blocked the fallback path in early testing.
  - `UPGRADE_AVAILABLE <current> <latest>` stdout contract preserved.
- **`skills/design-farmer/tests/test-version-check.sh`** (new) — 5 behavioral tests using `file://` fixtures:
  1. Primary path: newer release tag → `UPGRADE_AVAILABLE 0.0.6 9.9.9`.
  2. Primary path: tag equals local version → silent.
  3. Primary path: local ahead of tag → silent.
  4. Malformed API response → fallback to main SKILL.md → `UPGRADE_AVAILABLE 0.0.6 9.9.9`.
  5. Both sources unreachable → silent exit.
- **`skills/design-farmer/tests/run-all.sh`** — wired Suite 3 into the master runner.
- **`AGENTS.md`** — Testing Rules section updated from two to three suites, structure map lists `test-version-check.sh`.

## Validation

```
$ bash skills/design-farmer/tests/run-all.sh
...
RESULTS: 5 passed, 0 failed
Suite 3: PASSED

ALL SUITES PASSED
```

Structural validation (Suite 1) and semantic consistency (Suite 2) both still pass.

## Out of Scope

- Changing how versions are bumped or tagged in `scripts/release.sh`.
- Adding marketplace-specific refresh hooks.
- Altering the `_DF_UPDATE` / AskUserQuestion flow in `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)