### PR TITLE
feat: warn when marketplace cache collides with curl install

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -38,6 +38,8 @@ If you need to switch back (for example, to manage the skill alongside other non
 
 Marketplace installs live inside Claude Code's managed plugin cache, while the curl installer writes to `~/.claude/skills/design-farmer/`. When both are present, Claude Code may surface either copy depending on how it enumerates skills, and the two copies are not reconciled automatically. To keep behavior deterministic, install from exactly one channel per tool and run one of the migration flows above when switching.
 
+Both `install.sh` and `uninstall.sh` detect the marketplace cache at `~/.claude/plugins/cache/design-farmer/design-farmer` when the `claude` target is active, and print an advisory warning that lists both paths. The warning is non-fatal — the script still proceeds so existing automation is not broken — but it is your cue to pick one channel and run the matching migration flow.
+
 ## Universal installer (all tools)
 
 Run the installer script:

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,48 @@ require_command() {
   fi
 }
 
+# Claude Code stores marketplace-installed plugins under
+# $HOME/.claude/plugins/cache/<marketplace>/<plugin>/<version>/<plugin>.
+# For this repository both the marketplace and plugin name are 'design-farmer',
+# so the presence of the top-level cache directory is a reliable signal that
+# the plugin is already installed via the Claude Code Marketplace.
+marketplace_cache_dir() {
+  printf "%s/.claude/plugins/cache/%s/%s\n" "$HOME" "$SKILL_NAME" "$SKILL_NAME"
+}
+
+detect_marketplace_cache() {
+  local cache_dir
+  cache_dir="$(marketplace_cache_dir)"
+  if [ -d "$cache_dir" ]; then
+    return 0
+  fi
+  return 1
+}
+
+claude_is_selected() {
+  local tool
+  for tool in ${SELECTED[@]+"${SELECTED[@]}"}; do
+    if [ "$tool" = "claude" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+warn_marketplace_cache_collision_install() {
+  local cache_dir
+  cache_dir="$(marketplace_cache_dir)"
+  local curl_dir
+  curl_dir="$(tool_skill_dir claude)"
+  printf "%bWarning:%b a Claude Code marketplace install of %s was detected.\n" "$YELLOW" "$RESET" "$SKILL_NAME"
+  printf "  marketplace cache : %s\n" "$cache_dir"
+  printf "  curl install path : %s\n" "$curl_dir"
+  printf "  Both copies can stay enabled simultaneously and Claude Code does not\n"
+  printf "  reconcile them automatically. To avoid duplicate skills, install from\n"
+  printf "  exactly one channel per tool. See INSTALLATION.md -> 'Avoid running\n"
+  printf "  both channels at once' for safe migration flows.\n\n"
+}
+
 install_bundle_atomic() {
   local target_dir="$1"
   shift
@@ -394,6 +436,10 @@ for tool in "${SELECTED[@]}"; do
   printf "  - %s (%s) -> %s\n" "$(tool_label "$tool")" "$status" "$target_dir"
 done
 printf "\n"
+
+if claude_is_selected && detect_marketplace_cache; then
+  warn_marketplace_cache_collision_install
+fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
   printf "%bDone (dry run).%b\n" "$GREEN" "$RESET"

--- a/scripts/test-install-smoke.sh
+++ b/scripts/test-install-smoke.sh
@@ -690,6 +690,151 @@ test_uninstall_interactive_requires_terminal() {
   trap - RETURN
 }
 
+make_fake_marketplace_cache() {
+  local fake_home="$1"
+  # Mirror the actual Claude Code marketplace cache layout:
+  # $HOME/.claude/plugins/cache/<marketplace>/<plugin>/<version>/<plugin>
+  local cache_path="$fake_home/.claude/plugins/cache/design-farmer/design-farmer/9.9.9/design-farmer"
+  mkdir -p "$cache_path"
+  printf "fake marketplace copy\n" >"$cache_path/SKILL.md"
+}
+
+test_install_warns_on_marketplace_cache_collision_for_claude() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+  write_curl_stub "$fake_bin"
+  make_fake_marketplace_cache "$fake_home"
+
+  local output_file="$temp_dir/output.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" BRANCH="smoke-test-branch" \
+    "$BASH_BIN" "$INSTALLER" --tool claude >"$output_file" 2>&1
+
+  assert_contains "$output_file" "Claude Code marketplace install of design-farmer was detected"
+  assert_contains "$output_file" "marketplace cache :"
+  assert_contains "$output_file" "curl install path :"
+  assert_contains "$output_file" "install from"
+  assert_contains "$output_file" "Done!"
+
+  local claude_file
+  claude_file="$(installed_skill_file_path "claude" "$fake_home")"
+  if [[ ! -f "$claude_file" ]]; then
+    echo "ERROR: Install should still succeed alongside the warning"
+    cat "$output_file"
+    exit 1
+  fi
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_install_does_not_warn_without_marketplace_cache() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+  write_curl_stub "$fake_bin"
+
+  local output_file="$temp_dir/output.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" BRANCH="smoke-test-branch" \
+    "$BASH_BIN" "$INSTALLER" --tool claude >"$output_file" 2>&1
+
+  if grep -Fq "Claude Code marketplace install of design-farmer was detected" "$output_file"; then
+    echo "ERROR: Marketplace collision warning fired without any cache present"
+    cat "$output_file"
+    exit 1
+  fi
+
+  assert_contains "$output_file" "Done!"
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_install_does_not_warn_for_non_claude_target() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "codex" "$fake_home")"
+  write_curl_stub "$fake_bin"
+  # Cache is present, but claude is not a selected target — the warning
+  # should not fire because the user is only installing for codex.
+  make_fake_marketplace_cache "$fake_home"
+
+  local output_file="$temp_dir/output.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" BRANCH="smoke-test-branch" \
+    "$BASH_BIN" "$INSTALLER" --tool codex >"$output_file" 2>&1
+
+  if grep -Fq "Claude Code marketplace install of design-farmer was detected" "$output_file"; then
+    echo "ERROR: Marketplace collision warning fired for non-claude target"
+    cat "$output_file"
+    exit 1
+  fi
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
+test_uninstall_warns_on_marketplace_cache_collision_for_claude() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  local fake_home="$temp_dir/home"
+  local fake_bin="$temp_dir/bin"
+  mkdir -p "$fake_home"
+  mkdir -p "$(tool_marker_path "claude" "$fake_home")"
+  write_curl_stub "$fake_bin"
+
+  # Install the curl copy first, then seed the marketplace cache so the
+  # uninstaller sees the collision when it runs.
+  local install_output="$temp_dir/install.log"
+  HOME="$fake_home" PATH="$fake_bin:/usr/bin:/bin" BRANCH="smoke-test-branch" \
+    "$BASH_BIN" "$INSTALLER" --tool claude >"$install_output" 2>&1
+
+  make_fake_marketplace_cache "$fake_home"
+
+  local uninstall_output="$temp_dir/uninstall.log"
+  HOME="$fake_home" PATH="/usr/bin:/bin" \
+    "$BASH_BIN" "$UNINSTALLER" --tool claude >"$uninstall_output" 2>&1
+
+  assert_contains "$uninstall_output" "Claude Code marketplace install of design-farmer was detected"
+  assert_contains "$uninstall_output" "removes ONLY the curl-installed copy"
+  assert_contains "$uninstall_output" "Done!"
+
+  local claude_dir
+  claude_dir="$(installed_skill_dir_path "claude" "$fake_home")"
+  if [[ -d "$claude_dir" ]]; then
+    echo "ERROR: Curl install should be removed by uninstall even with warning"
+    cat "$uninstall_output"
+    exit 1
+  fi
+
+  local cache_dir
+  cache_dir="$fake_home/.claude/plugins/cache/design-farmer/design-farmer/9.9.9/design-farmer"
+  if [[ ! -d "$cache_dir" ]]; then
+    echo "ERROR: Uninstaller must not touch the marketplace cache"
+    cat "$uninstall_output"
+    exit 1
+  fi
+
+  rm -rf "$temp_dir"
+  trap - RETURN
+}
+
 main() {
   local tool="${1:-}"
   if [[ -z "$tool" ]]; then
@@ -753,6 +898,18 @@ main() {
 
   echo "[smoke] uninstall interactive path: requires terminal in CI"
   test_uninstall_interactive_requires_terminal
+
+  echo "[smoke] install path: warns on marketplace cache collision for claude"
+  test_install_warns_on_marketplace_cache_collision_for_claude
+
+  echo "[smoke] install path: silent when no marketplace cache is present"
+  test_install_does_not_warn_without_marketplace_cache
+
+  echo "[smoke] install path: silent when marketplace cache exists but claude is not targeted"
+  test_install_does_not_warn_for_non_claude_target
+
+  echo "[smoke] uninstall path: warns on marketplace cache collision for claude"
+  test_uninstall_warns_on_marketplace_cache_collision_for_claude
 
   echo "All install/uninstall smoke tests passed for tool=$tool"
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -171,6 +171,49 @@ select_interactively() {
   fi
 }
 
+# Claude Code stores marketplace-installed plugins under
+# $HOME/.claude/plugins/cache/<marketplace>/<plugin>/<version>/<plugin>.
+# For this repository both the marketplace and plugin name are 'design-farmer',
+# so the presence of the top-level cache directory is a reliable signal that
+# the plugin is also installed via the Claude Code Marketplace — which this
+# uninstaller intentionally does not touch.
+marketplace_cache_dir() {
+  printf "%s/.claude/plugins/cache/%s/%s\n" "$HOME" "$SKILL_NAME" "$SKILL_NAME"
+}
+
+detect_marketplace_cache() {
+  local cache_dir
+  cache_dir="$(marketplace_cache_dir)"
+  if [ -d "$cache_dir" ]; then
+    return 0
+  fi
+  return 1
+}
+
+claude_is_selected() {
+  local tool
+  for tool in ${SELECTED[@]+"${SELECTED[@]}"}; do
+    if [ "$tool" = "claude" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+warn_marketplace_cache_collision_uninstall() {
+  local cache_dir
+  cache_dir="$(marketplace_cache_dir)"
+  local curl_dir
+  curl_dir="$(tool_skill_dir claude)"
+  printf "%bWarning:%b a Claude Code marketplace install of %s was detected.\n" "$YELLOW" "$RESET" "$SKILL_NAME"
+  printf "  marketplace cache : %s\n" "$cache_dir"
+  printf "  curl install path : %s\n" "$curl_dir"
+  printf "  This uninstaller removes ONLY the curl-installed copy. The marketplace\n"
+  printf "  copy is managed by Claude Code and will remain active. Use Claude Code's\n"
+  printf "  Plugins -> Marketplace UI to remove it. See INSTALLATION.md ->\n"
+  printf "  'Avoid running both channels at once' for the full migration flow.\n\n"
+}
+
 safe_remove_target() {
   local target_dir="$1"
 
@@ -325,6 +368,10 @@ for tool in "${SELECTED[@]}"; do
   printf "  - %s (%s, %s) -> %s\n" "$(tool_label "$tool")" "$detected_status" "$install_status" "$target_dir"
 done
 printf "\n"
+
+if claude_is_selected && detect_marketplace_cache; then
+  warn_marketplace_cache_collision_uninstall
+fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
   printf "%bDone (dry run).%b\n" "$GREEN" "$RESET"


### PR DESCRIPTION
## Summary

Closes #93.

Add runtime detection of Claude Code marketplace installs to `install.sh` and `uninstall.sh`. When a user installs or uninstalls for the `claude` target and the marketplace cache at `~/.claude/plugins/cache/design-farmer/design-farmer` is present, the scripts print an advisory warning that lists both the marketplace cache path and the curl install path and points at `INSTALLATION.md` for the safe migration flow.

## Changes

- **`install.sh`**
  - `marketplace_cache_dir` / `detect_marketplace_cache` helpers resolve the Claude Code marketplace cache for `design-farmer`.
  - `claude_is_selected` returns 0 only when the `claude` target is part of the selected install set.
  - `warn_marketplace_cache_collision_install` prints an advisory warning explaining that two enabled copies can exist simultaneously and that Claude Code does not reconcile them.
  - The warning is emitted after "Selected targets" printing, before dry-run exit and before the install loop, so it is visible in both normal and dry-run mode.
- **`uninstall.sh`**
  - Same helpers and a `warn_marketplace_cache_collision_uninstall` message that clarifies the uninstaller removes ONLY the curl copy. Users must remove the marketplace copy through Claude Code's Plugins UI.
- **`scripts/test-install-smoke.sh`**
  - Four new behavioral tests, each creating a fake marketplace cache layout under the test HOME:
    1. Install warns when the cache is present for the claude target.
    2. Install is silent when no cache is present.
    3. Install is silent when the cache is present but only a non-claude target is selected.
    4. Uninstall warns, still removes the curl copy, and leaves the marketplace cache untouched.
- **`INSTALLATION.md`**
  - "Avoid running both channels at once" section now documents the runtime detection behavior and explains that the warning is advisory only.

## Validation

Ran the four new marketplace tests directly against the modified scripts:

```
=== Running marketplace collision tests directly ===
[1] install warns on collision
  PASS
[2] install does not warn without cache
  PASS
[3] install does not warn for non-claude target
  PASS
[4] uninstall warns on collision
  PASS
```

Full smoke test suite runs on the CI matrix (5 tools x 2 shells) under Linux bash 5. One local run under macOS bash 3.2 hit a pre-existing `set -u` quirk on `SELECTED=("${DETECTED[@]}")` with an empty array — that is not a regression from this PR and affects only the no-detected-tools dry-run path, which is already covered by CI.

## Out of Scope

- Removing or tampering with the marketplace-managed cache. The detection is strictly read-only.
- Forcing users to pick one channel — the warning is advisory.
- Changing Claude Code's loader precedence (outside this repository's control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)