### PR TITLE
ci: codify major action bump review policy and cache guard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,15 @@
 - [ ] Ran tests relevant to changed code/docs
 - [ ] Confirmed no unexpected file changes
 
+### Major Action Upgrade Evidence
+
+<!-- Complete this section when the PR changes a GitHub Action major version. -->
+
+- Intermediate major release notes reviewed:
+- Breaking changes classified as applicable / not applicable:
+- PR check evidence for the bumped branch:
+- Final decision / rollback note:
+
 ## Impact Notes
 
 <!-- Explain user-visible impact and any migration/release notes. -->

--- a/.github/workflows/skill-quality.yml
+++ b/.github/workflows/skill-quality.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '20.18'
+          # Keep CI behavior explicit even if package.json metadata changes later.
+          package-manager-cache: false
 
       - name: Run manifest sync unit tests
         run: node --test scripts/__tests__/release-sync-manifests.test.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,13 +137,21 @@ Recommended format:
 - Apply strict quoting and escaping for all dynamic shell values to prevent command injection and parsing bugs.
 - Use `mktemp` for temporary files; never write to predictable paths in `/tmp`.
 
+### GitHub Actions Major Upgrade Policy
+
+- Treat GitHub Action major-version bumps as compatibility changes, not routine dependency updates.
+- Review upstream release notes for each intermediate major version before merging a bump.
+- Classify documented breaking changes against this repository's actual workflow inputs and job behavior.
+- Require green PR checks on the bumped branch before merge.
+- If a major cannot be merged safely, document the reason and use the narrowest possible `.github/dependabot.yml` ignore rule.
+
 ### CI Baseline
 
 Repository-wide quality CI runs on every pull request and push to `main`.
 
 Jobs:
-- `validate-skill`: runs `bash scripts/validate-skill-md.sh` and `bash skills/design-farmer/tests/run-all.sh` — fails if any structural or semantic consistency check fails.
-- `validate-plugin`: pins `actions/setup-node@v4` to Node `20.18`, runs `node --test scripts/__tests__/release-sync-manifests.test.mjs` to exercise the schema-aware manifest sync module, then installs `@anthropic-ai/claude-code@~2.1.0` and runs `claude plugin validate .` — fails if the sync module regresses or if `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json` drifts from the Claude Code plugin/marketplace schema. Both the Node and CLI versions are pinned so upstream releases cannot break unrelated PRs without a commit in this repository; Dependabot (`.github/dependabot.yml`) bumps the GitHub Actions pins on a weekly schedule.
+- `validate-skill`: runs `bash scripts/validate-skill-md.sh` and `bash skills/design-farmer/tests/run-all.sh` — fails if any structural, semantic consistency, or version-check behavior suite fails.
+- `validate-plugin`: pins `actions/setup-node@v6` to Node `20.18`, explicitly disables package-manager auto-cache to keep CI behavior stable, runs `node --test scripts/__tests__/release-sync-manifests.test.mjs` to exercise the schema-aware manifest sync module, then installs `@anthropic-ai/claude-code@~2.1.0` and runs `claude plugin validate .` — fails if the sync module regresses or if `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json` drifts from the Claude Code plugin/marketplace schema. Both the Node and CLI versions are pinned so upstream releases cannot break unrelated PRs without a commit in this repository; Dependabot (`.github/dependabot.yml`) bumps the GitHub Actions pins on a weekly schedule.
 - `install-smoke`: runs `bash scripts/test-install-smoke.sh` across 5 tools x 2 shells (bash, zsh) — fails if any install/uninstall smoke test fails.
 
 All CI jobs must pass before a PR is merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,16 @@ Your PR should include:
 - Keep PR scope aligned to the linked issue acceptance criteria.
 - Merge once checks pass and reviewer approval is complete.
 
+### Major GitHub Action Version Bumps
+
+When a PR upgrades a GitHub Action across a major version (for example `actions/checkout@v4` -> `@v6`), review it as a compatibility change rather than a routine dependency bump.
+
+1. Read the upstream release notes for every intermediate major version.
+2. Classify each documented breaking change as applicable or not applicable to this repository's current workflow usage.
+3. Confirm the workflow inputs used here still match upstream expectations.
+4. Capture GitHub Actions evidence from the PR branch before merge.
+5. Record the decision in the PR description or thread: merge, defer with a reason, or add a narrow `.github/dependabot.yml` ignore rule.
+
 ## 7) Documentation Discipline
 
 When behavior or contributor workflow changes, update the matching docs in the same PR (README, installation guide, templates, policies, or process docs).

--- a/docs/project-103-major-action-bump-evaluation.md
+++ b/docs/project-103-major-action-bump-evaluation.md
@@ -1,0 +1,65 @@
+# project-103-major-action-bump-evaluation
+
+## Summary
+
+Issue #103 tracks how this repository evaluates and resolves major Dependabot PRs for GitHub Actions pins used by the `Skill Quality` workflow. The goal is to make those upgrades reproducible and auditable, record the evaluation directly on the bumped Dependabot PRs, and keep the repository policy/docs aligned with the resulting workflow state.
+
+## Evidence
+
+- GitHub issue `#103` calls for a documented evaluation procedure plus a recorded decision for Dependabot PRs `#101` (`actions/checkout` v4 -> v6) and `#102` (`actions/setup-node` v4 -> v6).
+- Before the resolution work started, `.github/workflows/skill-quality.yml` used `actions/checkout@v4` in all three jobs and `actions/setup-node@v4` in `validate-plugin`.
+- Dependabot PRs `#101` and `#102` both passed the full `Skill Quality` matrix on their own bumped branches before merge.
+- Upstream release notes document the relevant risks:
+  - `actions/checkout` v5/v6: runner compatibility moved to the Node 24 runtime baseline; v6 also changes persisted credential storage.
+  - `actions/setup-node` v5/v6: runner compatibility moved to the Node 24 runtime baseline; caching behavior changed, with `package-manager-cache: false` as the documented opt-out.
+- `package.json` currently does not declare a top-level `packageManager` field, so auto-cache would not be expected to activate today, but an explicit workflow setting is safer than relying on future metadata staying absent.
+
+## Current Gap
+
+The repository has Dependabot coverage for GitHub Actions pins, but it did not document how maintainers should evaluate major-version jumps before merging them. The PR template also did not require release-note review evidence for these upgrades, which made the decision process hard to audit later.
+
+## Proposed Scope
+
+### In Scope
+
+- Document a repository-wide major-action upgrade procedure in contributor and maintainer policy docs.
+- Add PR-template prompts that require release-note, breaking-change, and CI evidence for major action bumps.
+- Record the review outcome directly on Dependabot PRs `#101` and `#102`, then merge those PRs once their own CI passes.
+- Set `package-manager-cache: false` explicitly for `actions/setup-node@v6` so workflow behavior stays stable even if package metadata changes later.
+
+### Out of Scope
+
+- Changing the Dependabot cadence or ecosystem coverage.
+- Broad CI redesign unrelated to the action-version upgrades.
+- Rewriting issue #103 to match the exact current GitHub check count.
+
+## Architecture
+
+- `docs/project-103-major-action-bump-evaluation.md` records the scoped contract and evidence for this issue.
+- `CONTRIBUTING.md` becomes the canonical contributor-facing procedure for evaluating major GitHub Action bumps.
+- `AGENTS.md` records the repository-wide maintainer policy and CI baseline wording that matches the current workflow pins.
+- `.github/pull_request_template.md` requires reviewers/authors to include release-note and CI evidence when a PR changes major action versions.
+- `.github/workflows/skill-quality.yml` keeps the merged `@v6` action upgrades and adds the explicit `package-manager-cache: false` setting.
+
+## Acceptance Criteria
+
+- [ ] A `docs/project-103-*.md` contract exists and records the issue scope, evidence, and risks before implementation proceeds.
+- [ ] Contributor and maintainer docs explain how to evaluate major GitHub Action bumps, including intermediate-major release-note review and applicability checks.
+- [ ] The PR template asks for release-note and CI evidence when a PR changes a major GitHub Action version.
+- [ ] Dependabot PRs `#101` and `#102` have issue-`#103` evaluation comments recorded directly in their PR threads and are merged after their own bumped-branch CI passes.
+- [ ] `Skill Quality` uses `actions/checkout@v6` and `actions/setup-node@v6` with an explicit `package-manager-cache: false` setting.
+- [ ] Required local validation passes, and the branch PR can rely on GitHub Actions for full CI confirmation.
+
+## Dependencies
+
+- GitHub issue `#103`
+- Dependabot PRs `#101` and `#102`
+- PR comments on `#101` and `#102` that record the merge decision and upstream release-note applicability
+- `.github/workflows/skill-quality.yml`
+- `.github/dependabot.yml`
+
+## Risks
+
+- GitHub-hosted runner compatibility for Node 24-backed action runtimes is an upstream dependency; mitigation is to rely on GitHub-hosted runners and confirm green PR checks.
+- `actions/checkout@v6` changes how persisted credentials are stored; mitigation is that this workflow does not run authenticated post-checkout git commands or Docker container actions.
+- Future contributors could miss the evaluation process if it lives only in one file; mitigation is to document it in both `CONTRIBUTING.md` and `AGENTS.md`, then reinforce it in the PR template.


### PR DESCRIPTION
## Summary
- document the repository procedure for evaluating major GitHub Action bumps in `CONTRIBUTING.md`, `AGENTS.md`, the PR template, and `docs/project-103-major-action-bump-evaluation.md`
- record the issue-`#103` resolution context after reviewing and merging Dependabot PRs #101 and #102 directly on their own green branches
- keep `actions/setup-node@v6` behavior explicit with `package-manager-cache: false` so CI does not start caching automatically if package metadata changes later

## Validation
- `bash scripts/validate-skill-md.sh`
- `bash skills/design-farmer/tests/run-all.sh`
- `node --test scripts/__tests__/release-sync-manifests.test.mjs`
- `bash scripts/test-install-smoke.sh claude`

## Notes
- PR #101 comment: evaluated `actions/checkout` v5/v6 release notes and merged after green CI
- PR #102 comment: evaluated `actions/setup-node` v5/v6 release notes, documented the cache behavior decision, and merged after green CI

Closes #103